### PR TITLE
Some more typing

### DIFF
--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -9,6 +11,7 @@ import json
 import logging
 import mimetypes
 import traceback
+from typing import Any
 from urllib.parse import quote
 from aiohttp import WSCloseCode, web
 from .remote import RemoteObjectConnection, RemoteObjectConnectionException
@@ -22,10 +25,12 @@ class FontraServer:
 
     host: str
     httpPort: int
-    projectManager: object
-    launchWebBrowser: False
+    projectManager: Any
+    launchWebBrowser: bool = False
     cookieMaxAge: int = 7 * 24 * 60 * 60
-    allowedFileExtensions: set = frozenset(["css", "html", "ico", "js", "svg", "woff2"])
+    allowedFileExtensions: frozenset[str] = frozenset(
+        ["css", "html", "ico", "js", "svg", "woff2"]
+    )
 
     def setup(self):
         self.startupTime = datetime.now(timezone.utc).replace(microsecond=0)

--- a/src/fontra/core/server.py
+++ b/src/fontra/core/server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import partial


### PR DESCRIPTION
I think the `launchWebBrowser` attribute was mistyped. Fixed some more things Pylance complained about. Why was `projectManager` of type `object` before instead of `FileSystemProjectManager`?

And what is the deal with `self.projectManager.setupWebRoutes(self)`? There seems to be no such method defined in the codebase.