### PR TITLE
Refactor path changes

### DIFF
--- a/src/fontra/client/core/path-changes.js
+++ b/src/fontra/client/core/path-changes.js
@@ -51,6 +51,14 @@ export class PackedPathChangeRecorder {
       change(["path", "contourInfo", contourIndex], "=", "isClosed", close));
   }
 
+  setPointPosition(pointIndex, x, y) {
+    if (this.rollbackChanges) {
+      const [oldX, oldY] = this.path.getPointPosition(pointIndex);
+      this.rollbackChanges.push(change(["path"], "=xy", pointIndex, oldX, oldY));
+    }
+    this.editChanges.push(change(["path"], "=xy", pointIndex, x, y));
+  }
+
   setPointType(pointIndex, pointType) {
     this.rollbackChanges.push(
       change(["path", "pointTypes"], "=", pointIndex, this.path.pointTypes[pointIndex]));

--- a/src/fontra/client/core/path-changes.js
+++ b/src/fontra/client/core/path-changes.js
@@ -1,0 +1,78 @@
+import { range } from "./utils.js";
+
+
+export class PackedPathChangeRecorder {
+
+  constructor(path, rollbackChanges, editChanges) {
+    this.path = path;
+    this.rollbackChanges = rollbackChanges || [];
+    this.editChanges = editChanges || [];
+    this.contourIndices = [...range(path.contourInfo.length)];
+    this.contourPointIndices = new Array(path.contourInfo.length);
+  }
+
+  deleteContour(contourIndex) {
+    const contour = this.path.getContour(contourIndex);
+    this.contourIndices.splice(contourIndex, 1);
+    this.rollbackChanges.push(change(["path"], "insertContour", contourIndex, contour));
+    this.editChanges.push(change(["path"], "deleteContour", contourIndex));
+  }
+
+  insertContour(contourIndex, contour) {
+    this.contourIndices.splice(contourIndex, 0, null);
+    this.rollbackChanges.push(change(["path"], "deleteContour", contourIndex));
+    this.editChanges.push(change(["path"], "insertContour", contourIndex, contour));
+  }
+
+  deletePoint(contourIndex, contourPointIndex) {
+    const point = this.path.getContourPoint(contourIndex, contourPointIndex);
+    const contourPointIndices = this._getContourPointIndices(contourIndex);
+    contourPointIndices.splice(contourPointIndex, 1);
+    this.rollbackChanges.push(
+      change(["path"], "insertPoint", contourIndex, contourPointIndex, point));
+    this.editChanges.push(
+      change(["path"], "deletePoint", contourIndex, contourPointIndex));
+  }
+
+  insertPoint(contourIndex, contourPointIndex, point) {
+    const contourPointIndices = this._getContourPointIndices(contourIndex);
+    contourPointIndices.splice(contourPointIndex, 0, null);
+    this.rollbackChanges.push(
+      change(["path"], "deletePoint", contourIndex, contourPointIndex));
+    this.editChanges.push(
+      change(["path"], "insertPoint", contourIndex, contourPointIndex, point));
+  }
+
+  openCloseContour(contourIndex, close) {
+    this.rollbackChanges.push(
+      change(["path", "contourInfo", contourIndex], "=", "isClosed",
+        this.path.contourInfo[contourIndex].isClosed));
+    this.editChanges.push(
+      change(["path", "contourInfo", contourIndex], "=", "isClosed", close));
+  }
+
+  setPointType(pointIndex, pointType) {
+    this.rollbackChanges.push(
+      change(["path", "pointTypes"], "=", pointIndex, this.path.pointTypes[pointIndex]));
+    this.editChanges.push(
+      change(["path", "pointTypes"], "=", pointIndex, pointType));
+  }
+
+  _getContourPointIndices(contourIndex) {
+    if (this.contourPointIndices[contourIndex] === undefined) {
+      this.contourPointIndices[contourIndex] =
+        [...range(this.path.getNumPointsOfContour(this.contourIndices[contourIndex]))];
+    }
+    return this.contourPointIndices[contourIndex];
+  }
+
+}
+
+
+function change(path, func, ...args) {
+  return {
+    "p": path,
+    "f": func,
+    "a": args,
+  };
+}

--- a/src/fontra/client/core/path-changes.js
+++ b/src/fontra/client/core/path-changes.js
@@ -60,8 +60,13 @@ export class PackedPathChangeRecorder {
 
   _getContourPointIndices(contourIndex) {
     if (this.contourPointIndices[contourIndex] === undefined) {
-      this.contourPointIndices[contourIndex] =
-        [...range(this.path.getNumPointsOfContour(this.contourIndices[contourIndex]))];
+      const realContourIndex = this.contourIndices[contourIndex];
+      if (realContourIndex !== undefined) {
+        this.contourPointIndices[contourIndex] =
+          [...range(this.path.getNumPointsOfContour(this.contourIndices[contourIndex]))];
+        } else {
+          this.contourPointIndices[contourIndex] = []; // ????
+        }
     }
     return this.contourPointIndices[contourIndex];
   }

--- a/src/fontra/client/core/utils.js
+++ b/src/fontra/client/core/utils.js
@@ -207,3 +207,14 @@ export function *enumerate(iterable, start = 0) {
     i++;
   }
 }
+
+
+export function *range(start, stop, step = 1) {
+  if (stop === undefined) {
+    stop = start;
+    start = 0;
+  }
+  for (let i = start; i < stop; i += step) {
+    yield i;
+  }
+}

--- a/src/fontra/client/core/var-path.js
+++ b/src/fontra/client/core/var-path.js
@@ -219,6 +219,10 @@ export class VarPackedPath {
     this.setPointType(pointIndex, point.type, point.smooth);
   }
 
+  getPointPosition(pointIndex) {
+    return [this.coordinates[pointIndex * 2], this.coordinates[pointIndex * 2 + 1]];
+  }
+
   setPointPosition(pointIndex, x, y) {
     this.coordinates[pointIndex * 2] = x;
     this.coordinates[pointIndex * 2 + 1] = y;

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -156,6 +156,11 @@ class BehaviorBase {
     func(recorder);
   }
 
+  dropLastChange() {
+    this._rollbackChanges.splice(-1);
+    this._editChanges.splice(-1);
+  }
+
   getRollbackChange() {
     return consolidateChanges([...reversed(this._rollbackChanges)]);
   }
@@ -234,8 +239,7 @@ class AddPointsBehavior extends BehaviorBase {
 
   _setupDraggingChanges() {
     // Let's start over, revert the last insertPoint
-    this._rollbackChanges.splice(-1);
-    this._editChanges.splice(-1);
+    this.dropLastChange();
   }
 
   startDragging() {
@@ -245,10 +249,11 @@ class AddPointsBehavior extends BehaviorBase {
     this.handleInIndex = handleInIndex;
     this.handleOutIndex = handleOutIndex;
 
-    for (let i = 0; i < insertIndices.length; i++) {
-      this._rollbackChanges.push(deletePoint(this.contourIndex, insertIndices[i]));
-      this._editChanges.push(insertPoint(this.contourIndex, insertIndices[i], newPoints[i]));
-    }
+    this.record(path => {
+      for (let i = 0; i < insertIndices.length; i++) {
+        path.insertPoint(this.contourIndex, insertIndices[i], newPoints[i]);
+      }
+    });
 
     this._newSelection = new Set([`point/${this.contourStartPoint + this.handleOutIndex}`]);
   }

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -225,8 +225,7 @@ class AddPointsBehavior extends BehaviorBase {
 
   _setupInitialChanges(contourIndex, contourPointIndex, anchorPoint) {
     this._newSelection = new Set([`point/${this.contourStartPoint + contourPointIndex}`]);
-    this._rollbackChanges.push(deletePoint(contourIndex, contourPointIndex));
-    this._editChanges.push(insertPoint(contourIndex, contourPointIndex, anchorPoint));
+    this.record(path => path.insertPoint(contourIndex, contourPointIndex, anchorPoint));
   }
 
   _setupContourChanges(contourIndex) {
@@ -329,8 +328,7 @@ class AddPointsSingleHandleBehavior extends AddPointsBehavior {
 class AddContourAndPointsBehavior extends AddPointsSingleHandleBehavior {
 
   _setupContourChanges(contourIndex) {
-    this._rollbackChanges.push(deleteContour(contourIndex));
-    this._editChanges.push(appendEmptyContour(contourIndex));
+    this.record(path => path.insertContour(contourIndex, emptyContour()))
   }
 
 }

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -376,26 +376,16 @@ class CloseContourDragBehavior extends AddPointsBehavior {
   _setupContourChanges(contourIndex) {
     const path = this.path;
     this.firstPointIndex = path.getAbsolutePointIndex(contourIndex, 0);
-    this._rollbackChanges = [
-      openCloseContour(contourIndex, path.contourInfo[contourIndex].isClosed),
-    ];
-    this._editChanges = [
-      openCloseContour(contourIndex, true),
-    ];
-    if (!this.shouldAppend) {
-      // going backwards; connect, but make the connecting point the start point
-      const numPoints = path.getNumPointsOfContour(contourIndex);
-      const firstPoint = path.getPoint(this.firstPointIndex);
-      const lastPoint = path.getPoint(this.firstPointIndex + numPoints - 1);
-      this._rollbackChanges.push(
-        insertPoint(contourIndex, numPoints - 1, lastPoint),
-        deletePoint(contourIndex, 0),
-      );
-      this._editChanges.push(
-        deletePoint(contourIndex, numPoints - 1),
-        insertPoint(contourIndex, 0, lastPoint),
-      );
-    }
+    this.record(path => {
+      path.openCloseContour(contourIndex, true);
+      if (!this.shouldAppend) {
+        // going backwards; connect, but make the connecting point the start point
+        const numPoints = path.getNumPointsOfContour(contourIndex);
+        const lastPoint = path.getPoint(this.firstPointIndex + numPoints - 1);
+        path.deletePoint(contourIndex, numPoints - 1);
+        path.insertPoint(contourIndex, 0, lastPoint);
+      }
+    });
   }
 
   _setupInitialChanges(contourIndex, contourPointIndex, anchorPoint) {

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -444,22 +444,6 @@ function getAppendIndices(path, selection) {
 }
 
 
-export function movePoint(pointIndex, x, y) {
-  return {
-    "p": ["path"],
-    "f": "=xy",
-    "a": [pointIndex, x, y],
-  };
-}
-
-export function setPointType(pointIndex, pointType) {
-  return {
-    "p": ["path", "pointTypes"],
-    "f": "=",
-    "a": [pointIndex, pointType],
-  };
-}
-
 function emptyContour() {
   return {"coordinates": [], "pointTypes": [], "isClosed": false};
 }
@@ -478,6 +462,7 @@ function oppositeHandle(anchorPoint, handlePoint) {
     anchorPoint, vector.mulVector(vector.subVectors(handlePoint, anchorPoint), -1)
   );
 }
+
 
 function shiftConstrain(anchorPoint, handlePoint) {
   const delta = constrainHorVerDiag(vector.subVectors(handlePoint, anchorPoint));

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -446,38 +446,6 @@ function getAppendIndices(path, selection) {
 }
 
 
-function deleteContour(contourIndex) {
-  return {
-    "p": ["path"],
-    "f": "deleteContour",
-    "a": [contourIndex],
-  };
-}
-
-function appendEmptyContour(contourIndex) {
-  return {
-    "p": ["path"],
-    "f": "insertContour",
-    "a": [contourIndex, emptyContour()],
-  };
-}
-
-function deletePoint(contourIndex, contourPointIndex) {
-  return {
-    "p": ["path"],
-    "f": "deletePoint",
-    "a": [contourIndex, contourPointIndex],
-  };
-}
-
-function insertPoint(contourIndex, contourPointIndex, point) {
-  return {
-    "p": ["path"],
-    "f": "insertPoint",
-    "a": [contourIndex, contourPointIndex, point],
-  };
-}
-
 export function movePoint(pointIndex, x, y) {
   return {
     "p": ["path"],
@@ -493,15 +461,6 @@ export function setPointType(pointIndex, pointType) {
     "a": [pointIndex, pointType],
   };
 }
-
-function openCloseContour(contourIndex, close) {
-  return {
-    "p": ["path", "contourInfo", contourIndex],
-    "f": "=",
-    "a": ["isClosed", close],
-  };
-}
-
 
 function emptyContour() {
   return {"coordinates": [], "pointTypes": [], "isClosed": false};

--- a/src/fontra/views/editor/edit-tools-pen.js
+++ b/src/fontra/views/editor/edit-tools-pen.js
@@ -156,6 +156,14 @@ class BehaviorBase {
     func(recorder);
   }
 
+  getRollbackChange() {
+    return consolidateChanges([...reversed(this._rollbackChanges)]);
+  }
+
+  getInitialChange() {
+    return consolidateChanges(this._editChanges);
+  }
+
 }
 
 
@@ -180,14 +188,6 @@ class DeleteHandleBehavior extends BehaviorBase {
 
   getSelection() {
     return this._newSelection;
-  }
-
-  getRollbackChange() {
-    return consolidateChanges([...reversed(this._rollbackChanges)]);
-  }
-
-  getInitialChange() {
-    return consolidateChanges(this._editChanges);
   }
 
   getFinalChange() {
@@ -276,14 +276,6 @@ class AddPointsBehavior extends BehaviorBase {
 
   getSelection() {
     return this._newSelection;
-  }
-
-  getRollbackChange() {
-    return consolidateChanges([...reversed(this._rollbackChanges)]);
-  }
-
-  getInitialChange() {
-    return consolidateChanges(this._editChanges);
   }
 
   getIncrementalChange(point, constrain) {


### PR DESCRIPTION
Adding a recorder class to record path changes. This simplifies undo/redo-aware code a lot.