### PR TITLE
Double-click on undefined glyph, show "create new glyph" dialog

### DIFF
--- a/src/fontra/client/core/ui-dialog.js
+++ b/src/fontra/client/core/ui-dialog.js
@@ -37,13 +37,13 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
   let defaultButtonElement, cancelButtonElement;
   buttonDefs = buttonDefs.map(bd => {return {...bd};});
   if (buttonDefs.length === 1) {
-    buttonDefs[0].isDefault = true;
+    buttonDefs[0].isDefaultButton = true;
   }
   for (const [buttonIndex, buttonDef] of enumerate(buttonDefs, 4 - buttonDefs.length)) {
     const buttonElement = document.createElement("input");
     buttonElement.type = "button"
     buttonElement.className = `ui-dialog-button button-${buttonIndex}`;
-    if (buttonDef.isDefault) {
+    if (buttonDef.isDefaultButton) {
       buttonElement.classList.add("default");
       defaultButtonElement = buttonElement;
     }

--- a/src/fontra/client/core/ui-dialog.js
+++ b/src/fontra/client/core/ui-dialog.js
@@ -46,6 +46,8 @@ export function dialog(headline, message, buttonDefs, autoDismissTimeout) {
     if (buttonDef.isDefaultButton) {
       buttonElement.classList.add("default");
       defaultButtonElement = buttonElement;
+    } else if (buttonDef.isCancelButton) {
+      cancelButtonElement = buttonElement;
     }
     buttonElement.value = buttonDef.title;
     buttonElement.onclick = event => {

--- a/src/fontra/client/css/ui-styling.css
+++ b/src/fontra/client/css/ui-styling.css
@@ -183,7 +183,7 @@
   outline: none;  /* to catch key events we need to focus, but we don't want a focus border */
   max-width: 32em;
   overflow-wrap: normal;
-  font-size: 1.3em;
+  font-size: 1.15em;
   background-color: var(--editor-overlay-item-background-color);
   padding: 1em;
   border-radius: 0.5em;

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -112,6 +112,11 @@ export class PointerTool extends BaseTool {
           ],
         )
         if (result === "ok") {
+          dialog(
+            "⚠️ Work In Progress ⚠️",
+            "Creating a new glyph has not yet been implemented.",
+            [{"title": "Okay", "isDefaultButton": true}],
+          );
           // TODO: actually create a new glyph
           console.log("Create a new glyph:", positionedGlyph.character, positionedGlyph.glyphName);
         }

--- a/src/fontra/views/editor/edit-tools-pointer.js
+++ b/src/fontra/views/editor/edit-tools-pointer.js
@@ -105,10 +105,10 @@ export class PointerTool extends BaseTool {
         const charMsg = positionedGlyph.character ? ` for character “${positionedGlyph.character}” (U+${uniHex})` : "";
         const result = await dialog(
           `Create a new glyph “${positionedGlyph.glyphName}”?`,
-          `Click “Okay” if you want to create a new glyph named “${positionedGlyph.glyphName}”${charMsg}.`,
+          `Click “Create” if you want to create a new glyph named “${positionedGlyph.glyphName}”${charMsg}.`,
           [
-            {"title": "No", "resultValue": "no", "isCancelButton": true},
-            {"title": "Okay", "resultValue": "ok", "isDefaultButton": true},
+            {"title": "Cancel", "resultValue": "no", "isCancelButton": true},
+            {"title": "Create", "resultValue": "ok", "isDefaultButton": true},
           ],
         )
         if (result === "ok") {


### PR DESCRIPTION
Towards implementing #52.

This shows a dialog when you double-click a placeholder glyph in the editor.

To be done in later PRs:
- Actually create a new glyph
- Figure out undo for glyph creation