### PR TITLE
Schedule glyph writes

### DIFF
--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -19,6 +19,8 @@ def remoteMethod(method):
 class FontHandler:
     def __init__(self, backend, readOnly=False):
         self.backend = backend
+        if not hasattr(self.backend, "putGlyph"):
+            readOnly = True
         self.readOnly = readOnly
         self.connections = set()
         self.glyphUsedBy = {}
@@ -161,7 +163,7 @@ class FontHandler:
         glyphName = change["p"][1]
         glyph = await self.getChangedGlyph(glyphName)
         applyChange(dict(glyphs={glyphName: glyph}), change)
-        if hasattr(self.backend, "putGlyph") and not self.readOnly:
+        if not self.readOnly:
             self.scheduleGlyphWrite(glyphName, glyph)
 
     def scheduleGlyphWrite(self, glyphName, glyph):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -24,7 +24,7 @@ class FontHandler:
         self.glyphUsedBy = {}
         self.glyphMadeOf = {}
         self.clientData = defaultdict(dict)
-        self.changedGlyphs = {}
+        self.changedGlyphs = {}  # TODO: should perhaps be a LRU cache
         if hasattr(self.backend, "watchExternalChanges"):
             self._watcherTask = asyncio.create_task(self.watchExternalChanges())
         self._processGlyphWritesEvent = asyncio.Event()

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -50,7 +50,12 @@ class FontHandler:
             while self._glyphsScheduledForWrite:
                 glyphName, glyph = popFirstItem(self._glyphsScheduledForWrite)
                 logger.info(f"write {glyphName} to backend")
-                await self.backend.putGlyph(glyphName, glyph)
+                try:
+                    await self.backend.putGlyph(glyphName, glyph)
+                except Exception as e:
+                    logger.error("exception while writing glyph: %r", e)
+                    # TODO: notify the source connection
+                    await self.reloadGlyphs([glyphName])
                 await asyncio.sleep(0)
             self._processGlyphWritesEvent.clear()
 

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -128,7 +128,9 @@ class FontHandler:
         await self.broadcastChange(liveChange, connection, True)
 
     @remoteMethod
-    async def editFinal(self, finalChange, rollbackChange, editLabel, broadcast=False, *, connection):
+    async def editFinal(
+        self, finalChange, rollbackChange, editLabel, broadcast=False, *, connection
+    ):
         # TODO: use finalChange, rollbackChange, editLabel for history recording
         # TODO: locking/checking
         await self.updateServerGlyph(finalChange)

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -16,6 +16,7 @@ import {
 } from "../core/rectangle.js";
 import { getRemoteProxy } from "../core/remote.js";
 import { SceneView } from "../core/scene-view.js"
+import { dialog }from "../core/ui-dialog.js";
 import { Form } from "../core/ui-form.js";
 import { List } from "../core/ui-list.js";
 import { Sliders } from "../core/ui-sliders.js";
@@ -715,6 +716,15 @@ export class EditorController {
       this.updateSelectionInfo();
     }
     this.canvasController.setNeedsUpdate();
+  }
+
+  async messageFromServer(headline, message) {
+    // don't await for the dialog result, the server doesn't need an answer
+    dialog(
+      headline,
+      message,
+      [{"title": "Okay", "isDefaultButton": true}],
+    )
   }
 
   async setupFromWindowLocation() {

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -719,7 +719,7 @@ export class EditorController {
   }
 
   async messageFromServer(headline, message) {
-    // don't await for the dialog result, the server doesn't need an answer
+    // don't await the dialog result, the server doesn't need an answer
     dialog(
       headline,
       message,


### PR DESCRIPTION
- queue glyph writes (mostly to prevent two sequential changes to a single glyph being written out in parallel)
- catch write failures and recover from them, and notify the client