### PR TITLE
Generalize subscribe

### DIFF
--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -41,6 +41,10 @@ export class FontController {
     this._resolveInitialized();
   }
 
+  getCachedGlyphNames() {
+    return this._glyphsPromiseCache.keys();
+  }
+
   codePointForGlyph(glyphName) {
     const reverseCmap = this.reverseCmap;
     const cmap = this.cmap;

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -161,10 +161,6 @@ export class FontController {
     return glyph?.getSourceIndex(location);
   }
 
-  async subscribeLiveGlyphChanges(glyphNames) {
-    this.font.subscribeLiveGlyphChanges(glyphNames);
-  }
-
   addEditListener(listener) {
     this._editListeners.add(listener);
   }

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from .classes import classSchema, classCastFuncs
 
 
@@ -272,7 +273,7 @@ def addPatternToPattern(matchPattern, patternToAdd):
     for key, valueB in patternToAdd.items():
         valueA = matchPattern.get(key, _MISSING)
         if valueA is _MISSING or valueB is None:
-            matchPattern[key] = valueB
+            matchPattern[key] = deepcopy(valueB)
         elif valueA is not None:
             addPatternToPattern(valueA, valueB)
         else:

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -165,12 +165,6 @@ class FontHandler:
         removeFromPattern(matchPattern, pathOrPattern)
 
     @remoteMethod
-    async def subscribeLiveGlyphChanges(self, glyphNames, *, connection):
-        # TODO: replace this method with something more generic
-        matchPattern = self._getClientData(connection, LIVE_CHANGES_PATTERN_KEY, {})
-        matchPattern["glyphs"] = dict.fromkeys(glyphNames)
-
-    @remoteMethod
     async def editIncremental(self, liveChange, *, connection):
         await self.broadcastChange(liveChange, connection, True)
 

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -184,13 +184,16 @@ class FontHandler:
             matchPatternKey = LIVE_CHANGES_PATTERN_KEY
         else:
             matchPatternKey = CHANGES_PATTERN_KEY
-        connections = []
-        for connection in self.connections:
-            matchPattern = self._getClientData(connection, matchPatternKey, {})
-            if connection != sourceConnection and matchChangePattern(
-                change, matchPattern
-            ):
-                connections.append(connection)
+
+        connections = [
+            connection
+            for connection in self.connections
+            if connection != sourceConnection
+            and matchChangePattern(
+                change, self._getClientData(connection, matchPatternKey, {})
+            )
+        ]
+
         await asyncio.gather(
             *[connection.proxy.externalChange(change) for connection in connections]
         )

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -6,12 +6,12 @@ import functools
 import logging
 import traceback
 from .changes import (
-    addPathToPattern,
+    addToPattern,
     applyChange,
     collectChangePaths,
     filterChangePattern,
     matchChangePattern,
-    removePathFromPattern,
+    removeFromPattern,
 )
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 
@@ -145,24 +145,24 @@ class FontHandler:
         return self.clientData[connection.clientUUID].setdefault(key, default)
 
     @remoteMethod
-    async def subscribeChanges(self, path, *, connection):
+    async def subscribeChanges(self, pathOrPattern, *, connection):
         matchPattern = self._getClientData(connection, CHANGES_PATTERN_KEY, {})
-        addPathToPattern(matchPattern, path)
+        addToPattern(matchPattern, pathOrPattern)
 
     @remoteMethod
-    async def unsubscribeChanges(self, path, *, connection):
+    async def unsubscribeChanges(self, pathOrPattern, *, connection):
         matchPattern = self._getClientData(connection, CHANGES_PATTERN_KEY, {})
-        removePathFromPattern(matchPattern, path)
+        removeFromPattern(matchPattern, pathOrPattern)
 
     @remoteMethod
-    async def subscribeLiveChanges(self, path, *, connection):
+    async def subscribeLiveChanges(self, pathOrPattern, *, connection):
         matchPattern = self._getClientData(connection, LIVE_CHANGES_PATTERN_KEY, {})
-        addPathToPattern(matchPattern, path)
+        addToPattern(matchPattern, pathOrPattern)
 
     @remoteMethod
-    async def unsubscribeLiveChanges(self, path, *, connection):
+    async def unsubscribeLiveChanges(self, pathOrPattern, *, connection):
         matchPattern = self._getClientData(connection, LIVE_CHANGES_PATTERN_KEY, {})
-        removePathFromPattern(matchPattern, path)
+        removeFromPattern(matchPattern, pathOrPattern)
 
     @remoteMethod
     async def subscribeLiveGlyphChanges(self, glyphNames, *, connection):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -144,24 +144,17 @@ class FontHandler:
         return self.clientData[connection.clientUUID].setdefault(key, default)
 
     @remoteMethod
-    async def subscribeChanges(self, pathOrPattern, *, connection):
-        matchPattern = self._getClientData(connection, CHANGES_PATTERN_KEY, {})
-        addToPattern(matchPattern, pathOrPattern)
+    async def subscribeChanges(self, pathOrPattern, isLiveChange, *, connection):
+        self._adjustMatchPattern(addToPattern, pathOrPattern, isLiveChange, connection)
 
     @remoteMethod
-    async def unsubscribeChanges(self, pathOrPattern, *, connection):
-        matchPattern = self._getClientData(connection, CHANGES_PATTERN_KEY, {})
-        removeFromPattern(matchPattern, pathOrPattern)
+    async def unsubscribeChanges(self, pathOrPattern, isLiveChange, *, connection):
+        self._adjustMatchPattern(removeFromPattern, pathOrPattern, isLiveChange, connection)
 
-    @remoteMethod
-    async def subscribeLiveChanges(self, pathOrPattern, *, connection):
-        matchPattern = self._getClientData(connection, LIVE_CHANGES_PATTERN_KEY, {})
-        addToPattern(matchPattern, pathOrPattern)
-
-    @remoteMethod
-    async def unsubscribeLiveChanges(self, pathOrPattern, *, connection):
-        matchPattern = self._getClientData(connection, LIVE_CHANGES_PATTERN_KEY, {})
-        removeFromPattern(matchPattern, pathOrPattern)
+    def _adjustMatchPattern(self, func, pathOrPattern, isLiveChange, connection):
+        key = LIVE_CHANGES_PATTERN_KEY if isLiveChange else CHANGES_PATTERN_KEY
+        matchPattern = self._getClientData(connection, key, {})
+        func(matchPattern, pathOrPattern)
 
     @remoteMethod
     async def editIncremental(self, liveChange, *, connection):

--- a/src/fontra/views/editor/scene-model.js
+++ b/src/fontra/views/editor/scene-model.js
@@ -225,33 +225,28 @@ export class SceneModel {
       this.fontController, this.glyphLines, this.getGlobalLocation(), this._localLocations,
       this.textAlignment,
     );
-    const previousUsedGlyphNames = this.usedGlyphNames;
-    const previousCachedGlyphNames = this.cachedGlyphNames;
+
     const usedGlyphNames = getUsedGlyphNames(this.fontController, this.positionedLines);
     const cachedGlyphNames = difference(this.fontController.getCachedGlyphNames(), usedGlyphNames);
 
-    if (!isEqualSet(usedGlyphNames, previousUsedGlyphNames)) {
-      const unsubscribeGlyphNames = difference(previousUsedGlyphNames, usedGlyphNames);
-      const subscribeGlyphNames = difference(usedGlyphNames, previousUsedGlyphNames);
-      if (unsubscribeGlyphNames.size) {
-        this.fontController.font.unsubscribeLiveChanges(makeGlyphNamesPattern(unsubscribeGlyphNames));
-      }
-      if (subscribeGlyphNames.size) {
-        this.fontController.font.subscribeLiveChanges(makeGlyphNamesPattern(subscribeGlyphNames));
-      }
-      this.usedGlyphNames = usedGlyphNames;
-    }
+    this._adjustSubscriptions(usedGlyphNames, this.usedGlyphNames, true);
+    this._adjustSubscriptions(cachedGlyphNames, this.cachedGlyphNames, false);
 
-    if (!isEqualSet(cachedGlyphNames, previousCachedGlyphNames)) {
-      const unsubscribeGlyphNames = difference(previousCachedGlyphNames, cachedGlyphNames);
-      const subscribeGlyphNames = difference(cachedGlyphNames, previousCachedGlyphNames);
-      if (unsubscribeGlyphNames.size) {
-        this.fontController.font.unsubscribeChanges(makeGlyphNamesPattern(unsubscribeGlyphNames));
-      }
-      if (subscribeGlyphNames.size) {
-        this.fontController.font.subscribeChanges(makeGlyphNamesPattern(subscribeGlyphNames));
-      }
-      this.cachedGlyphNames = cachedGlyphNames;
+    this.usedGlyphNames = usedGlyphNames;
+    this.cachedGlyphNames = cachedGlyphNames;
+  }
+
+  _adjustSubscriptions(currentGlyphNames, previousGlyphNames, isLiveChange) {
+    if (isEqualSet(currentGlyphNames, previousGlyphNames)) {
+      return;
+    }
+    const unsubscribeGlyphNames = difference(previousGlyphNames, currentGlyphNames);
+    const subscribeGlyphNames = difference(currentGlyphNames, previousGlyphNames);
+    if (unsubscribeGlyphNames.size) {
+      this.fontController.font.unsubscribeChanges(makeGlyphNamesPattern(unsubscribeGlyphNames), isLiveChange);
+    }
+    if (subscribeGlyphNames.size) {
+      this.fontController.font.subscribeChanges(makeGlyphNamesPattern(subscribeGlyphNames), isLiveChange);
     }
   }
 


### PR DESCRIPTION
- Get rid of specialized subscribeLiveGlyphChanges
- Allow (un)subscribe(Live)Changes to take pattern dicts in addition to path lists
- Client keeps track of which glyphs have been subscribed to; use that to minimize (un)subscribe calls

To do:
- [x] Get rid of implicit server-side subscribe by `fonthandler.getGlyph()`