### PR TITLE
Rename "reverse cmap" to "glyph map" and "cmap" to "character map"

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -54,7 +54,7 @@ class DesignspaceBackend:
         self.axes = axes
         self.loadSources()
         self.buildFileNameMapping()
-        self.reverseCmap = getGlyphMapFromGlyphSet(self.defaultSourceGlyphSet)
+        self.glyphMap = getGlyphMapFromGlyphSet(self.defaultSourceGlyphSet)
         self.savedGlyphModificationTimes = {}
 
     def close(self):
@@ -120,7 +120,7 @@ class DesignspaceBackend:
             glifFileNames[fileName] = glyphName
 
     async def getGlyphMap(self):
-        return self.reverseCmap
+        return self.glyphMap
 
     async def getGlyph(self, glyphName):
         glyph = VariableGlyph(glyphName)
@@ -178,7 +178,7 @@ class DesignspaceBackend:
 
     async def putGlyph(self, glyphName, glyph):
         modTimes = set()
-        unicodes = self.reverseCmap.get(glyphName, [])
+        unicodes = self.glyphMap.get(glyphName, [])
         for layer in glyph.layers:
             glyphSet = self.ufoGlyphSets[layer.name]
             writeGlyphSetContents = glyphName not in glyphSet
@@ -343,13 +343,13 @@ def buildUFOLayerGlyph(
 
 
 def getGlyphMapFromGlyphSet(glyphSet):
-    revCmap = {}
+    glyphMap = {}
     for glyphName in glyphSet.keys():
         glifData = glyphSet.getGLIF(glyphName)
         gn, unicodes = extractGlyphNameAndUnicodes(glifData)
         assert gn == glyphName, (gn, glyphName)
-        revCmap[glyphName] = unicodes
-    return revCmap
+        glyphMap[glyphName] = unicodes
+    return glyphMap
 
 
 async def ufoWatcher(ufoPaths, glifFileNames, savedGlyphModificationTimes):

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -54,7 +54,7 @@ class DesignspaceBackend:
         self.axes = axes
         self.loadSources()
         self.buildFileNameMapping()
-        self.reverseCmap = getReverseCmapFromGlyphSet(self.defaultSourceGlyphSet)
+        self.reverseCmap = getGlyphMapFromGlyphSet(self.defaultSourceGlyphSet)
         self.savedGlyphModificationTimes = {}
 
     def close(self):
@@ -119,7 +119,7 @@ class DesignspaceBackend:
         for glyphName, fileName in glyphSet.contents.items():
             glifFileNames[fileName] = glyphName
 
-    async def getReverseCmap(self):
+    async def getGlyphMap(self):
         return self.reverseCmap
 
     async def getGlyph(self, glyphName):
@@ -342,7 +342,7 @@ def buildUFOLayerGlyph(
     return layerGlyph, pen.replay
 
 
-def getReverseCmapFromGlyphSet(glyphSet):
+def getGlyphMapFromGlyphSet(glyphSet):
     revCmap = {}
     for glyphName in glyphSet.keys():
         glifData = glyphSet.getGLIF(glyphName)

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -33,7 +33,7 @@ class OTFBackend:
     def close(self):
         pass
 
-    async def getReverseCmap(self):
+    async def getGlyphMap(self):
         return self.revCmap
 
     def hasGlyph(self, glyphName):

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -19,13 +19,13 @@ class OTFBackend:
             if "CFF2" in self.font
             else None
         )
-        self.cmap = self.font.getBestCmap()
-        revCmap = {}
+        self.characterMap = self.font.getBestCmap()
+        glyphMap = {}
         for glyphName in self.font.getGlyphOrder():
-            revCmap[glyphName] = []
-        for code, glyphName in sorted(self.cmap.items()):
-            revCmap[glyphName].append(code)
-        self.revCmap = revCmap
+            glyphMap[glyphName] = []
+        for code, glyphName in sorted(self.characterMap.items()):
+            glyphMap[glyphName].append(code)
+        self.glyphMap = glyphMap
         self.glyphSet = self.font.getGlyphSet()
         self.variationGlyphSets = {}
         return self
@@ -34,7 +34,7 @@ class OTFBackend:
         pass
 
     async def getGlyphMap(self):
-        return self.revCmap
+        return self.glyphMap
 
     def hasGlyph(self, glyphName):
         return glyphName in self.glyphSet

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -2,10 +2,13 @@
 // A `characterMap` is an object with integer numbers representing unicode code
 // points as keys, and glyph names as values. Note: we're using a JS Object, not
 // Map, so the code point keys are stored as (decimal) string representations of
-// the integers. Multiple code points may map to the same glyph name.
+// the integers. Multiple code points may map to the same glyph name. Each code
+// point maps to exactly one glyph name.
 //
-// A `glyphMap` maps glyph names to arrays of (integer) code points. A code
-// point may only occur one time in the entire mapping.
+// A `glyphMap` is the opposite of a `characterMap`: it maps glyph names to
+// arrays of (integer) code points. A code point may only occur one time in the
+// entire mapping. Code point arrays may contain any number of code points:
+// any glyph can be mapped to zero or more code points.
 //
 // For the sake of determinism, this module tries to keep the code point arrays
 // in sorted order, even though the order has no intrinsic meaning.

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -99,7 +99,7 @@ export function getGlyphMapProxy(revCmap, cmap) {
 }
 
 
-export function getCmapProxy(cmap, revCmap) {
+export function getCharacterMapProxy(cmap, revCmap) {
   //
   // Return a wrapper (Proxy) for `cmap`, that behaves exactly like `cmap`,
   // while keeping the matching `revCmap` synchronized.

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -17,7 +17,7 @@
 //
 
 
-export function makeReverseMapping(cmap) {
+export function makeGlyphMapFromCharacterMap(cmap) {
   // Return a `revCmap` constructed from `cmap`
   const revCmap = {};
   for (const [codeStr, glyphName] of Object.entries(cmap)) {
@@ -32,7 +32,7 @@ export function makeReverseMapping(cmap) {
 }
 
 
-export function makeMappingFromReverseMapping(revCmap, strict = true) {
+export function makeCharacterMapFromGlyphMap(revCmap, strict = true) {
   // Return a `cmap` constructed from `revCmap`
   // If the `strict` flag is `true` (default), an Error is thrown when a code
   // point is defined multiple times.

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -58,7 +58,7 @@ export function makeCharacterMapFromGlyphMap(revCmap, strict = true) {
 }
 
 
-export function getReverseCmapProxy(revCmap, cmap) {
+export function getGlyphMapProxy(revCmap, cmap) {
   //
   // Return a wrapper (Proxy) for `revCmap`, that behaves exactly like `revCmap`,
   // while keeping the matching `cmap` synchronized.

--- a/src/fontra/client/core/cmap.js
+++ b/src/fontra/client/core/cmap.js
@@ -68,9 +68,9 @@ export function getGlyphMapProxy(glyphMap, characterMap) {
   // `glyphMap` and `characterMap` are expected to be synchronized on input.
   //
   // Any changes made to `glyphMap` via the `glyphMap` proxy will be reflected in
-  // the `characterMap` object. This does *not* catch mutations in the code point arrays
-  // themselves, but only wholesale *replacement* the code point arrays. In other
-  // words: you must treat the code point arrays as immutable.
+  // the `characterMap` object. This does *not* catch mutations in the code point
+  // arrays themselves, but only wholesale *replacement* the code point arrays.
+  // In other words: you must treat the code point arrays as immutable.
   //
 
   const handler = {
@@ -103,13 +103,13 @@ export function getGlyphMapProxy(glyphMap, characterMap) {
 
 export function getCharacterMapProxy(characterMap, glyphMap) {
   //
-  // Return a wrapper (Proxy) for `characterMap`, that behaves exactly like `characterMap`,
-  // while keeping the matching `glyphMap` synchronized.
+  // Return a wrapper (Proxy) for `characterMap`, that behaves exactly like
+  // `characterMap`, while keeping the matching `glyphMap` synchronized.
   //
   // `characterMap` and `glyphMap` are expected to be synchronized on input.
   //
-  // Any changes made to `characterMap` via the `characterMap` proxy will be reflected in
-  // the `glyphMap` object.
+  // Any changes made to `characterMap` via the `characterMap` proxy will be
+  // reflected in the `glyphMap` object.
   //
 
   const handler = {

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -46,9 +46,8 @@ export class FontController {
   }
 
   codePointForGlyph(glyphName) {
-    const reverseCmap = this.glyphMap;
     const characterMap = this.characterMap;
-    for (const codePoint of reverseCmap[glyphName] || []) {
+    for (const codePoint of this.glyphMap || []) {
       if (characterMap[codePoint] === glyphName) {
         return codePoint;
       }

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -47,7 +47,7 @@ export class FontController {
 
   codePointForGlyph(glyphName) {
     const characterMap = this.characterMap;
-    for (const codePoint of this.glyphMap || []) {
+    for (const codePoint of this.glyphMap[glyphName] || []) {
       if (characterMap[codePoint] === glyphName) {
         return codePoint;
       }

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -33,8 +33,8 @@ export class FontController {
   }
 
   async initialize() {
-    this.reverseCmap = await this.font.getGlyphMap();
-    this.cmap = makeCharacterMapFromGlyphMap(this.reverseCmap, false);
+    this.glyphMap = await this.font.getGlyphMap();
+    this.characterMap = makeCharacterMapFromGlyphMap(this.glyphMap, false);
     this.globalAxes = await this.font.getGlobalAxes();
     this.unitsPerEm = await this.font.getUnitsPerEm();
     this.fontLib = await this.font.getFontLib();
@@ -46,10 +46,10 @@ export class FontController {
   }
 
   codePointForGlyph(glyphName) {
-    const reverseCmap = this.reverseCmap;
-    const cmap = this.cmap;
+    const reverseCmap = this.glyphMap;
+    const characterMap = this.characterMap;
     for (const codePoint of reverseCmap[glyphName] || []) {
-      if (cmap[codePoint] === glyphName) {
+      if (characterMap[codePoint] === glyphName) {
         return codePoint;
       }
     }
@@ -65,7 +65,7 @@ export class FontController {
   }
 
   async hasGlyph(glyphName) {
-    return glyphName in this.reverseCmap;
+    return glyphName in this.glyphMap;
   }
 
   getGlyph(glyphName) {

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -4,7 +4,7 @@ import {
   consolidateChanges,
   matchChangePath,
 } from "./changes.js";
-import { makeMappingFromReverseMapping } from "./cmap.js";
+import { makeCharacterMapFromGlyphMap } from "./cmap.js";
 import { StaticGlyphController, VariableGlyphController } from "./glyph-controller.js";
 import { LRUCache } from "./lru-cache.js";
 import { StaticGlyph, VariableGlyph } from "./var-glyph.js";
@@ -33,8 +33,8 @@ export class FontController {
   }
 
   async initialize() {
-    this.reverseCmap = await this.font.getReverseCmap();
-    this.cmap = makeMappingFromReverseMapping(this.reverseCmap, false);
+    this.reverseCmap = await this.font.getGlyphMap();
+    this.cmap = makeCharacterMapFromGlyphMap(this.reverseCmap, false);
     this.globalAxes = await this.font.getGlobalAxes();
     this.unitsPerEm = await this.font.getUnitsPerEm();
     this.fontLib = await this.font.getFontLib();

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -125,8 +125,8 @@ class FontHandler:
         return glyph
 
     @remoteMethod
-    async def getReverseCmap(self, *, connection):
-        return await self.backend.getReverseCmap()
+    async def getGlyphMap(self, *, connection):
+        return await self.backend.getGlyphMap()
 
     @remoteMethod
     async def getGlobalAxes(self, *, connection):

--- a/test-js/test-cmap.js
+++ b/test-js/test-cmap.js
@@ -10,7 +10,7 @@ import {
 import { enumerate } from "../src/fontra/client/core/utils.js";
 
 
-describe("cmap tests", () => {
+describe("characterMap tests", () => {
 
   const makeGlyphMapFromCharacterMap_testData = [
     [{}, {}],
@@ -20,9 +20,9 @@ describe("cmap tests", () => {
     [{2: "double", 1: "double"}, {"double": [1, 2]}],
   ];
 
-  for (const [i, [cmap, expectedRevCmap]] of enumerate(makeGlyphMapFromCharacterMap_testData)) {
+  for (const [i, [characterMap, expectedGlyphMap]] of enumerate(makeGlyphMapFromCharacterMap_testData)) {
     it(`makeGlyphMapFromCharacterMap test ${i}`, () => {
-      expect(makeGlyphMapFromCharacterMap(cmap)).to.deep.equal(expectedRevCmap);
+      expect(makeGlyphMapFromCharacterMap(characterMap)).to.deep.equal(expectedGlyphMap);
     });
   }
 
@@ -36,132 +36,132 @@ describe("cmap tests", () => {
     [{"two": [1], "one": [1]}, {1: "one"}, false, null],
   ];
 
-  for (const [i, [revCmap, expectedCmap, strict, error]] of enumerate(makeCharacterMapFromGlyphMap_testData)) {
+  for (const [i, [glyphMap, expectedCharacterMap, strict, error]] of enumerate(makeCharacterMapFromGlyphMap_testData)) {
     it(`makeCharacterMapFromGlyphMap test ${i}`, () => {
       if (!error) {
-        expect(makeCharacterMapFromGlyphMap(revCmap, strict)).to.deep.equal(expectedCmap);
+        expect(makeCharacterMapFromGlyphMap(glyphMap, strict)).to.deep.equal(expectedCharacterMap);
       } else {
-        expect(() => makeCharacterMapFromGlyphMap(revCmap, strict)).to.throw(error);
+        expect(() => makeCharacterMapFromGlyphMap(glyphMap, strict)).to.throw(error);
       }
     });
   }
 
   it("makeGlyphMapFromCharacterMap test simple", () => {
-    const cmap = {};
-    expect(makeGlyphMapFromCharacterMap(cmap)).to.deep.equal({});
+    const characterMap = {};
+    expect(makeGlyphMapFromCharacterMap(characterMap)).to.deep.equal({});
   });
 
   it("getReverseCmapProxy add items", () => {
-    const cmap = {};
-    const revCmapData = {};
-    const revCmap = getReverseCmapProxy(revCmapData, cmap);
+    const characterMap = {};
+    const glyphMapData = {};
+    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
 
-    revCmap["space"] = [32];
-    revCmap["double"] = [33, 34];
+    glyphMap["space"] = [32];
+    glyphMap["double"] = [33, 34];
 
-    expect(cmap).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(revCmapData).to.deep.equal({"space": [32], "double": [33, 34]});
+    expect(characterMap).to.deep.equal({"32": "space", "33": "double", "34": "double"});
+    expect(glyphMapData).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
   it("getReverseCmapProxy replace items", () => {
-    const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
-    const revCmap = getReverseCmapProxy(revCmapData, cmap);
+    const characterMap = {"32": "space", "33": "test"};
+    const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
+    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
 
-    revCmap["space"] = [32, 34];
-    expect(cmap).to.deep.equal({"32": "space", "33": "test", "34": "space"});
-    expect(revCmap).to.deep.equal({"space": [32, 34], "test": [33]});
+    glyphMap["space"] = [32, 34];
+    expect(characterMap).to.deep.equal({"32": "space", "33": "test", "34": "space"});
+    expect(glyphMap).to.deep.equal({"space": [32, 34], "test": [33]});
   });
 
   it("getReverseCmapProxy replace items with same", () => {
-    const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
-    const revCmap = getReverseCmapProxy(revCmapData, cmap);
+    const characterMap = {"32": "space", "33": "test"};
+    const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
+    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
 
-    revCmap["space"] = [32];
-    revCmap["test"] = [33];
-    expect(cmap).to.deep.equal({"32": "space", "33": "test"});
-    expect(revCmap).to.deep.equal({"space": [32], "test": [33]});
+    glyphMap["space"] = [32];
+    glyphMap["test"] = [33];
+    expect(characterMap).to.deep.equal({"32": "space", "33": "test"});
+    expect(glyphMap).to.deep.equal({"space": [32], "test": [33]});
   });
 
   it("getReverseCmapProxy delete items", () => {
-    const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
-    const revCmap = getReverseCmapProxy(revCmapData, cmap);
+    const characterMap = {"32": "space", "33": "test"};
+    const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
+    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
 
-    delete revCmap["space"];
-    expect(cmap).to.deep.equal({"33": "test"});
-    expect(revCmap).to.deep.equal({"test": [33]});
+    delete glyphMap["space"];
+    expect(characterMap).to.deep.equal({"33": "test"});
+    expect(glyphMap).to.deep.equal({"test": [33]});
 
-    delete revCmap["test"];
-    expect(cmap).to.deep.equal({});
-    expect(revCmap).to.deep.equal({});
+    delete glyphMap["test"];
+    expect(characterMap).to.deep.equal({});
+    expect(glyphMap).to.deep.equal({});
   });
 
   it("getCmapProxy add items", () => {
-    const cmapData = {};
-    const revCmap = {};
-    const cmap = getCmapProxy(cmapData, revCmap);
+    const characterMapData = {};
+    const glyphMap = {};
+    const characterMap = getCmapProxy(characterMapData, glyphMap);
 
-    cmap[32] = "space";
-    cmap[33] = "double";
-    cmap[34] = "double";
-    expect(cmapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(revCmap).to.deep.equal({"space": [32], "double": [33, 34]});
+    characterMap[32] = "space";
+    characterMap[33] = "double";
+    characterMap[34] = "double";
+    expect(characterMapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
+    expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
   it("getCmapProxy replace items", () => {
-    const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
-    const cmap = getCmapProxy(cmapData, revCmap);
+    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
+    const characterMap = getCmapProxy(characterMapData, glyphMap);
 
-    cmap[32] = "spacey";
-    cmap[34] = "doubly";
-    expect(cmapData).to.deep.equal({"32": "spacey", "33": "double", "34": "doubly"});
-    expect(revCmap).to.deep.equal({"spacey": [32], "double": [33], "doubly": [34]});
+    characterMap[32] = "spacey";
+    characterMap[34] = "doubly";
+    expect(characterMapData).to.deep.equal({"32": "spacey", "33": "double", "34": "doubly"});
+    expect(glyphMap).to.deep.equal({"spacey": [32], "double": [33], "doubly": [34]});
   });
 
   it("getCmapProxy replace items with same", () => {
-    const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
-    const cmap = getCmapProxy(cmapData, revCmap);
+    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
+    const characterMap = getCmapProxy(characterMapData, glyphMap);
 
-    cmap[32] = "space";
-    cmap[34] = "double";
-    expect(cmapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
-    expect(revCmap).to.deep.equal({"space": [32], "double": [33, 34]});
+    characterMap[32] = "space";
+    characterMap[34] = "double";
+    expect(characterMapData).to.deep.equal({"32": "space", "33": "double", "34": "double"});
+    expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
   it("getCmapProxy delete items", () => {
-    const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
-    const cmap = getCmapProxy(cmapData, revCmap);
+    const characterMapData = {"32": "space", "33": "double", "34": "double"};
+    const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
+    const characterMap = getCmapProxy(characterMapData, glyphMap);
 
-    delete cmap[32];
-    expect(cmapData).to.deep.equal({"33": "double", "34": "double"});
-    expect(revCmap).to.deep.equal({"double": [33, 34]});
+    delete characterMap[32];
+    expect(characterMapData).to.deep.equal({"33": "double", "34": "double"});
+    expect(glyphMap).to.deep.equal({"double": [33, 34]});
 
-    delete cmap[33];
-    expect(cmapData).to.deep.equal({"34": "double"});
-    expect(revCmap).to.deep.equal({"double": [34]});
+    delete characterMap[33];
+    expect(characterMapData).to.deep.equal({"34": "double"});
+    expect(glyphMap).to.deep.equal({"double": [34]});
 
-    delete cmap[34];
-    expect(cmapData).to.deep.equal({});
-    expect(revCmap).to.deep.equal({});
+    delete characterMap[34];
+    expect(characterMapData).to.deep.equal({});
+    expect(glyphMap).to.deep.equal({});
   });
 
   it("getCmapProxy add items, ensure sorted", () => {
-    const cmapData = {};
-    const revCmap = {};
-    const cmap = getCmapProxy(cmapData, revCmap);
+    const characterMapData = {};
+    const glyphMap = {};
+    const characterMap = getCmapProxy(characterMapData, glyphMap);
 
-    cmap[35] = "double";
-    expect(revCmap).to.deep.equal({"double": [35]});
-    cmap[33] = "double";
-    expect(revCmap).to.deep.equal({"double": [33, 35]});
-    cmap[34] = "double";
-    expect(revCmap).to.deep.equal({"double": [33, 34, 35]});
-    expect(cmapData).to.deep.equal({"33": "double", "34": "double", "35": "double"});
+    characterMap[35] = "double";
+    expect(glyphMap).to.deep.equal({"double": [35]});
+    characterMap[33] = "double";
+    expect(glyphMap).to.deep.equal({"double": [33, 35]});
+    characterMap[34] = "double";
+    expect(glyphMap).to.deep.equal({"double": [33, 34, 35]});
+    expect(characterMapData).to.deep.equal({"33": "double", "34": "double", "35": "double"});
   });
 
 });

--- a/test-js/test-cmap.js
+++ b/test-js/test-cmap.js
@@ -2,7 +2,7 @@ import chai from "chai";
 const expect = chai.expect;
 
 import {
-  getCmapProxy,
+  getCharacterMapProxy,
   getGlyphMapProxy,
   makeCharacterMapFromGlyphMap,
   makeGlyphMapFromCharacterMap,
@@ -98,10 +98,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({});
   });
 
-  it("getCmapProxy add items", () => {
+  it("getCharacterMapProxy add items", () => {
     const characterMapData = {};
     const glyphMap = {};
-    const characterMap = getCmapProxy(characterMapData, glyphMap);
+    const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[32] = "space";
     characterMap[33] = "double";
@@ -110,10 +110,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
-  it("getCmapProxy replace items", () => {
+  it("getCharacterMapProxy replace items", () => {
     const characterMapData = {"32": "space", "33": "double", "34": "double"};
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
-    const characterMap = getCmapProxy(characterMapData, glyphMap);
+    const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[32] = "spacey";
     characterMap[34] = "doubly";
@@ -121,10 +121,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({"spacey": [32], "double": [33], "doubly": [34]});
   });
 
-  it("getCmapProxy replace items with same", () => {
+  it("getCharacterMapProxy replace items with same", () => {
     const characterMapData = {"32": "space", "33": "double", "34": "double"};
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
-    const characterMap = getCmapProxy(characterMapData, glyphMap);
+    const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[32] = "space";
     characterMap[34] = "double";
@@ -132,10 +132,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
-  it("getCmapProxy delete items", () => {
+  it("getCharacterMapProxy delete items", () => {
     const characterMapData = {"32": "space", "33": "double", "34": "double"};
     const glyphMap = makeGlyphMapFromCharacterMap(characterMapData);
-    const characterMap = getCmapProxy(characterMapData, glyphMap);
+    const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     delete characterMap[32];
     expect(characterMapData).to.deep.equal({"33": "double", "34": "double"});
@@ -150,10 +150,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({});
   });
 
-  it("getCmapProxy add items, ensure sorted", () => {
+  it("getCharacterMapProxy add items, ensure sorted", () => {
     const characterMapData = {};
     const glyphMap = {};
-    const characterMap = getCmapProxy(characterMapData, glyphMap);
+    const characterMap = getCharacterMapProxy(characterMapData, glyphMap);
 
     characterMap[35] = "double";
     expect(glyphMap).to.deep.equal({"double": [35]});

--- a/test-js/test-cmap.js
+++ b/test-js/test-cmap.js
@@ -3,7 +3,7 @@ const expect = chai.expect;
 
 import {
   getCmapProxy,
-  getReverseCmapProxy,
+  getGlyphMapProxy,
   makeCharacterMapFromGlyphMap,
   makeGlyphMapFromCharacterMap,
 } from "../src/fontra/client/core/cmap.js";
@@ -51,10 +51,10 @@ describe("characterMap tests", () => {
     expect(makeGlyphMapFromCharacterMap(characterMap)).to.deep.equal({});
   });
 
-  it("getReverseCmapProxy add items", () => {
+  it("getGlyphMapProxy add items", () => {
     const characterMap = {};
     const glyphMapData = {};
-    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
+    const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     glyphMap["space"] = [32];
     glyphMap["double"] = [33, 34];
@@ -63,20 +63,20 @@ describe("characterMap tests", () => {
     expect(glyphMapData).to.deep.equal({"space": [32], "double": [33, 34]});
   });
 
-  it("getReverseCmapProxy replace items", () => {
+  it("getGlyphMapProxy replace items", () => {
     const characterMap = {"32": "space", "33": "test"};
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
-    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
+    const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     glyphMap["space"] = [32, 34];
     expect(characterMap).to.deep.equal({"32": "space", "33": "test", "34": "space"});
     expect(glyphMap).to.deep.equal({"space": [32, 34], "test": [33]});
   });
 
-  it("getReverseCmapProxy replace items with same", () => {
+  it("getGlyphMapProxy replace items with same", () => {
     const characterMap = {"32": "space", "33": "test"};
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
-    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
+    const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     glyphMap["space"] = [32];
     glyphMap["test"] = [33];
@@ -84,10 +84,10 @@ describe("characterMap tests", () => {
     expect(glyphMap).to.deep.equal({"space": [32], "test": [33]});
   });
 
-  it("getReverseCmapProxy delete items", () => {
+  it("getGlyphMapProxy delete items", () => {
     const characterMap = {"32": "space", "33": "test"};
     const glyphMapData = makeGlyphMapFromCharacterMap(characterMap);
-    const glyphMap = getReverseCmapProxy(glyphMapData, characterMap);
+    const glyphMap = getGlyphMapProxy(glyphMapData, characterMap);
 
     delete glyphMap["space"];
     expect(characterMap).to.deep.equal({"33": "test"});

--- a/test-js/test-cmap.js
+++ b/test-js/test-cmap.js
@@ -4,15 +4,15 @@ const expect = chai.expect;
 import {
   getCmapProxy,
   getReverseCmapProxy,
-  makeMappingFromReverseMapping,
-  makeReverseMapping,
+  makeCharacterMapFromGlyphMap,
+  makeGlyphMapFromCharacterMap,
 } from "../src/fontra/client/core/cmap.js";
 import { enumerate } from "../src/fontra/client/core/utils.js";
 
 
 describe("cmap tests", () => {
 
-  const makeReverseMapping_testData = [
+  const makeGlyphMapFromCharacterMap_testData = [
     [{}, {}],
     [{1: "one"}, {"one": [1]}],
     [{1: "one", 2: "two"}, {"one": [1], "two": [2]}],
@@ -20,13 +20,13 @@ describe("cmap tests", () => {
     [{2: "double", 1: "double"}, {"double": [1, 2]}],
   ];
 
-  for (const [i, [cmap, expectedRevCmap]] of enumerate(makeReverseMapping_testData)) {
-    it(`makeReverseMapping test ${i}`, () => {
-      expect(makeReverseMapping(cmap)).to.deep.equal(expectedRevCmap);
+  for (const [i, [cmap, expectedRevCmap]] of enumerate(makeGlyphMapFromCharacterMap_testData)) {
+    it(`makeGlyphMapFromCharacterMap test ${i}`, () => {
+      expect(makeGlyphMapFromCharacterMap(cmap)).to.deep.equal(expectedRevCmap);
     });
   }
 
-  const makeMappingFromReverseMapping_testData = [
+  const makeCharacterMapFromGlyphMap_testData = [
     [{}, {}, true, null],
     [{"one": [1]}, {1: "one"}, true, null],
     [{"one": [1], "two": [2]}, {1: "one", 2: "two"}, true, null],
@@ -36,19 +36,19 @@ describe("cmap tests", () => {
     [{"two": [1], "one": [1]}, {1: "one"}, false, null],
   ];
 
-  for (const [i, [revCmap, expectedCmap, strict, error]] of enumerate(makeMappingFromReverseMapping_testData)) {
-    it(`makeMappingFromReverseMapping test ${i}`, () => {
+  for (const [i, [revCmap, expectedCmap, strict, error]] of enumerate(makeCharacterMapFromGlyphMap_testData)) {
+    it(`makeCharacterMapFromGlyphMap test ${i}`, () => {
       if (!error) {
-        expect(makeMappingFromReverseMapping(revCmap, strict)).to.deep.equal(expectedCmap);
+        expect(makeCharacterMapFromGlyphMap(revCmap, strict)).to.deep.equal(expectedCmap);
       } else {
-        expect(() => makeMappingFromReverseMapping(revCmap, strict)).to.throw(error);
+        expect(() => makeCharacterMapFromGlyphMap(revCmap, strict)).to.throw(error);
       }
     });
   }
 
-  it("makeReverseMapping test simple", () => {
+  it("makeGlyphMapFromCharacterMap test simple", () => {
     const cmap = {};
-    expect(makeReverseMapping(cmap)).to.deep.equal({});
+    expect(makeGlyphMapFromCharacterMap(cmap)).to.deep.equal({});
   });
 
   it("getReverseCmapProxy add items", () => {
@@ -65,7 +65,7 @@ describe("cmap tests", () => {
 
   it("getReverseCmapProxy replace items", () => {
     const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeReverseMapping(cmap);
+    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
     const revCmap = getReverseCmapProxy(revCmapData, cmap);
 
     revCmap["space"] = [32, 34];
@@ -75,7 +75,7 @@ describe("cmap tests", () => {
 
   it("getReverseCmapProxy replace items with same", () => {
     const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeReverseMapping(cmap);
+    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
     const revCmap = getReverseCmapProxy(revCmapData, cmap);
 
     revCmap["space"] = [32];
@@ -86,7 +86,7 @@ describe("cmap tests", () => {
 
   it("getReverseCmapProxy delete items", () => {
     const cmap = {"32": "space", "33": "test"};
-    const revCmapData = makeReverseMapping(cmap);
+    const revCmapData = makeGlyphMapFromCharacterMap(cmap);
     const revCmap = getReverseCmapProxy(revCmapData, cmap);
 
     delete revCmap["space"];
@@ -112,7 +112,7 @@ describe("cmap tests", () => {
 
   it("getCmapProxy replace items", () => {
     const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeReverseMapping(cmapData);
+    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
     const cmap = getCmapProxy(cmapData, revCmap);
 
     cmap[32] = "spacey";
@@ -123,7 +123,7 @@ describe("cmap tests", () => {
 
   it("getCmapProxy replace items with same", () => {
     const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeReverseMapping(cmapData);
+    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
     const cmap = getCmapProxy(cmapData, revCmap);
 
     cmap[32] = "space";
@@ -134,7 +134,7 @@ describe("cmap tests", () => {
 
   it("getCmapProxy delete items", () => {
     const cmapData = {"32": "space", "33": "double", "34": "double"};
-    const revCmap = makeReverseMapping(cmapData);
+    const revCmap = makeGlyphMapFromCharacterMap(cmapData);
     const cmap = getCmapProxy(cmapData, revCmap);
 
     delete cmap[32];

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -871,10 +871,10 @@ getGlyphMapTestData = [
 async def test_getGlyphMap(backendName, numGlyphs, testMapping):
     font = getTestFont(backendName)
     with contextlib.closing(font):
-        revCmap = await font.getGlyphMap()
-        assert numGlyphs == len(revCmap)
+        glyphMap = await font.getGlyphMap()
+        assert numGlyphs == len(glyphMap)
         for glyphName, unicodes in testMapping.items():
-            assert revCmap[glyphName] == unicodes
+            assert glyphMap[glyphName] == unicodes
 
 
 @pytest.mark.asyncio

--- a/test-py/test_font.py
+++ b/test-py/test_font.py
@@ -855,23 +855,23 @@ getGlyphNamesTestData = [
 async def test_getGlyphNames(backendName, numGlyphs, firstFourGlyphNames):
     font = getTestFont(backendName)
     with contextlib.closing(font):
-        glyphNames = sorted(await font.getReverseCmap())
+        glyphNames = sorted(await font.getGlyphMap())
         assert numGlyphs == len(glyphNames)
         assert firstFourGlyphNames == sorted(glyphNames)[:4]
 
 
-getReverseCmapTestData = [
+getGlyphMapTestData = [
     ("designspace", 51, {"A": [ord("A"), ord("a")], "B": [ord("B"), ord("b")], "I.narrow": []}),
     ("ufo", 51, {"A": [ord("A"), ord("a")], "B": [ord("B"), ord("b")], "I.narrow": []}),
 ]
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("backendName, numGlyphs, testMapping", getReverseCmapTestData)
-async def test_getReverseCmap(backendName, numGlyphs, testMapping):
+@pytest.mark.parametrize("backendName, numGlyphs, testMapping", getGlyphMapTestData)
+async def test_getGlyphMap(backendName, numGlyphs, testMapping):
     font = getTestFont(backendName)
     with contextlib.closing(font):
-        revCmap = await font.getReverseCmap()
+        revCmap = await font.getGlyphMap()
         assert numGlyphs == len(revCmap)
         for glyphName, unicodes in testMapping.items():
             assert revCmap[glyphName] == unicodes


### PR DESCRIPTION
Motivation:
- Unhappiness with the term "reverse cmap"

Solution:
- a "character map" maps characters (code points) to glyph names
- g "glyph map" maps glyph names to characters (code points)

TODO:
- [x] change local variable names and attribute names to reflect this