### PR TITLE
Generalize "local data", to not be only for glyph data

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -123,6 +123,9 @@ class DesignspaceBackend:
         return self.glyphMap
 
     async def getGlyph(self, glyphName):
+        if glyphName not in self.glyphMap:
+            return None
+
         glyph = VariableGlyph(glyphName)
 
         sources = []

--- a/src/fontra/backends/opentype.py
+++ b/src/fontra/backends/opentype.py
@@ -36,10 +36,9 @@ class OTFBackend:
     async def getGlyphMap(self):
         return self.glyphMap
 
-    def hasGlyph(self, glyphName):
-        return glyphName in self.glyphSet
-
     async def getGlyph(self, glyphName):
+        if glyphName not in self.glyphSet:
+            return None
         defaultLayerName = "<default>"
         glyph = VariableGlyph(glyphName)
         staticGlyph = serializeGlyph(self.glyphSet, glyphName)

--- a/src/fontra/client/core/changes.js
+++ b/src/fontra/client/core/changes.js
@@ -289,17 +289,17 @@ export function applyChange(subject, change) {
 
 
 export function matchChangePath(change, matchPath) {
-  return matchChangePattern(change, pathToPattern(matchPath));
+  return matchChangePattern(change, patternFromPath(matchPath));
 }
 
 
-function pathToPattern(matchPath) {
+function patternFromPath(matchPath) {
   const pattern = {};
   let node;
   if (matchPath.length == 1) {
     node = null;
   } else if (matchPath.length > 1) {
-    node = pathToPattern(matchPath.slice(1));
+    node = patternFromPath(matchPath.slice(1));
   }
   if (node !== undefined) {
     pattern[matchPath[0]] = node;

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -252,6 +252,23 @@ def subtractFromPattern(matchPattern, pathOrPattern):
     return _subtractPatternFromPattern(matchPattern, pathOrPattern)
 
 
+def intersectPatterns(patternA, patternB):
+    result = {}
+    for key, valueA in patternA.items():
+        valueB = patternB.get(key, _MISSING)
+        if valueB is _MISSING:
+            continue
+        if valueA is None:
+            result[key] = valueB
+        elif valueB is None:
+            result[key] = valueA
+        else:
+            childResult = intersectPatterns(valueA, valueB)
+            if childResult:
+                result[key] = childResult
+    return result
+
+
 def _addPatternToPattern(matchPattern, patternToAdd):
     result = {**matchPattern}
     for key, valueB in patternToAdd.items():

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -1,19 +1,20 @@
+from typing import Mapping, MutableMapping, MutableSequence, Sequence
 from .classes import classSchema, classCastFuncs
 
 
 def setItem(subject, key, item, *, itemCast=None):
     if itemCast is not None:
         item = itemCast(item)
-    if isinstance(subject, (dict, list)):
+    if isinstance(subject, (MutableMapping, MutableSequence)):
         subject[key] = item
     else:
         setattr(subject, key, item)
 
 
 def delAttr(subject, key, *, itemCast=None):
-    if isinstance(subject, list):
+    if isinstance(subject, Sequence):
         raise TypeError("can't call delattr on list")
-    elif isinstance(subject, dict):
+    elif isinstance(subject, MutableMapping):
         del subject[key]
     else:
         delattr(subject, key)
@@ -87,7 +88,7 @@ def _applyChange(subject, change, *, itemCast=None):
 
     for pathElement in path:
         itemCast = None
-        if isinstance(subject, (dict, list, tuple)):
+        if isinstance(subject, (Mapping, Sequence)):
             subject = subject[pathElement]
         else:
             itemCast = getItemCast(subject, pathElement, "subtype")

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -253,6 +253,9 @@ def subtractFromPattern(matchPattern, pathOrPattern):
 
 
 def intersectPatterns(patternA, patternB):
+    """Return the intersection of `patternA` and `patternB`. The resulting pattern
+    will only match items that are included in both patterns.
+    """
     result = {}
     for key, valueA in patternA.items():
         valueB = patternB.get(key, _MISSING)

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -213,11 +213,11 @@ def _normalizeChange(change):
     return result
 
 
-def pathToPattern(matchPath):
+def patternFromPath(matchPath):
     pattern = {}
     if matchPath:
         pattern[matchPath[0]] = (
-            None if len(matchPath) == 1 else pathToPattern(matchPath[1:])
+            None if len(matchPath) == 1 else patternFromPath(matchPath[1:])
         )
     return pattern
 
@@ -233,7 +233,7 @@ def patternUnion(matchPattern, pathOrPattern):
     `pathOrPattern` is either a list of path elements, or a pattern dict.
     """
     if isinstance(pathOrPattern, list):
-        pathOrPattern = pathToPattern(pathOrPattern)
+        pathOrPattern = patternFromPath(pathOrPattern)
     return _patternUnion(matchPattern, pathOrPattern)
 
 
@@ -248,7 +248,7 @@ def patternDifference(matchPattern, pathOrPattern):
     `pathOrPattern` is either a list of path elements, or a pattern dict.
     """
     if isinstance(pathOrPattern, list):
-        pathOrPattern = pathToPattern(pathOrPattern)
+        pathOrPattern = patternFromPath(pathOrPattern)
     return _patternDifference(matchPattern, pathOrPattern)
 
 

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -222,7 +222,7 @@ def pathToPattern(matchPath):
     return pattern
 
 
-def addToPattern(matchPattern, pathOrPattern):
+def patternUnion(matchPattern, pathOrPattern):
     """Return a pattern which is the sum of `matchPattern` and `pathOrPattern`:
     it matches both input arguments.
 
@@ -234,10 +234,10 @@ def addToPattern(matchPattern, pathOrPattern):
     """
     if isinstance(pathOrPattern, list):
         pathOrPattern = pathToPattern(pathOrPattern)
-    return _addPatternToPattern(matchPattern, pathOrPattern)
+    return _patternUnion(matchPattern, pathOrPattern)
 
 
-def subtractFromPattern(matchPattern, pathOrPattern):
+def patternDifference(matchPattern, pathOrPattern):
     """Return a pattern which is `matchPattern` with `pathOrPattern` subtracted:
     it does not match `pathOrPattern`.
 
@@ -249,10 +249,10 @@ def subtractFromPattern(matchPattern, pathOrPattern):
     """
     if isinstance(pathOrPattern, list):
         pathOrPattern = pathToPattern(pathOrPattern)
-    return _subtractPatternFromPattern(matchPattern, pathOrPattern)
+    return _patternDifference(matchPattern, pathOrPattern)
 
 
-def intersectPatterns(patternA, patternB):
+def patternIntersect(patternA, patternB):
     """Return the intersection of `patternA` and `patternB`. The resulting pattern
     will only match items that are included in both patterns.
     """
@@ -266,20 +266,20 @@ def intersectPatterns(patternA, patternB):
         elif valueB is None:
             result[key] = valueA
         else:
-            childResult = intersectPatterns(valueA, valueB)
+            childResult = patternIntersect(valueA, valueB)
             if childResult:
                 result[key] = childResult
     return result
 
 
-def _addPatternToPattern(matchPattern, patternToAdd):
+def _patternUnion(matchPattern, patternToAdd):
     result = {**matchPattern}
     for key, valueB in patternToAdd.items():
         valueA = matchPattern.get(key, _MISSING)
         if valueA is _MISSING or valueB is None:
             result[key] = valueB
         elif valueA is not None:
-            result[key] = _addPatternToPattern(valueA, valueB)
+            result[key] = _patternUnion(valueA, valueB)
         else:
             # valueA is None -- matchPattern already matches a prefix of
             # patternToAdd: nothing to do
@@ -287,7 +287,7 @@ def _addPatternToPattern(matchPattern, patternToAdd):
     return result
 
 
-def _subtractPatternFromPattern(matchPattern, patternToRemove):
+def _patternDifference(matchPattern, patternToRemove):
     result = {**matchPattern}
     for key, valueB in patternToRemove.items():
         valueA = matchPattern.get(key, _MISSING)
@@ -298,7 +298,7 @@ def _subtractPatternFromPattern(matchPattern, patternToRemove):
         elif valueA is None:
             pass
         else:
-            result[key] = _subtractPatternFromPattern(valueA, valueB)
+            result[key] = _patternDifference(valueA, valueB)
             if not result[key]:
                 del result[key]
     return result

--- a/src/fontra/core/changes.py
+++ b/src/fontra/core/changes.py
@@ -214,6 +214,7 @@ def _normalizeChange(change):
 
 
 def patternFromPath(matchPath):
+    """Given a list of path elements, return a pattern dict."""
     pattern = {}
     if matchPath:
         pattern[matchPath[0]] = (
@@ -223,12 +224,8 @@ def patternFromPath(matchPath):
 
 
 def patternUnion(patternA, patternB):
-    """Return a pattern which is the sum of `patternA` and `patternB`:
-    it matches both input arguments.
-
-    If `patternA` matches a prefix of `patternB`, or if `patternB`
-    is already included in `patternA`, the return value will be equal to
-    `patternA`.
+    """Return a pattern which is the union of `patternA` and `patternB`:
+    the result will match everything from `patternA` and `patternB`.
     """
     result = {**patternA}
     for key, valueB in patternB.items():
@@ -245,12 +242,8 @@ def patternUnion(patternA, patternB):
 
 
 def patternDifference(patternA, patternB):
-    """Return a pattern which is `patternA` with `patternB` subtracted:
-    it does not match `patternB`.
-
-    If `patternA` matches a prefix of `patternB`, or if `patternB`
-    was not included in `patternA` to begin with, the return value will be
-    equal to `patternA`.
+    """Return a pattern which is `patternA` minus `patternB`: the result will
+    only match the items from `patternA` that are not included in `patternB`.
     """
     result = {**patternA}
     for key, valueB in patternB.items():

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -91,13 +91,13 @@ class Font:
     lib: dict = field(default_factory=dict)
     axes: list[GlobalAxis] = field(default_factory=list)
 
-    def _trackAddedAttributeNames(self):
+    def _trackAssignedAttributeNames(self):
         # see fonthandler.py
-        self._addedAttributeNames = set()
+        self._assignedAttributeNames = set()
 
     def __setattr__(self, attrName, value):
-        if hasattr(self, "_addedAttributeNames"):
-            self._addedAttributeNames.add(attrName)
+        if hasattr(self, "_assignedAttributeNames"):
+            self._assignedAttributeNames.add(attrName)
         super().__setattr__(attrName, value)
 
 

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -169,4 +169,5 @@ if __name__ == "__main__":
 
     schema = classesToStrings(classSchema)
     print("// This file is generated, don't edit!")
-    print("export const classSchema =", json.dumps(schema, indent=2))
+    schemaJSON = json.dumps(schema, indent=2)
+    print(f"export const classSchema = {schemaJSON};")

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -91,6 +91,15 @@ class Font:
     lib: dict = field(default_factory=dict)
     axes: list[GlobalAxis] = field(default_factory=list)
 
+    def _trackAddedAttributeNames(self):
+        # see fonthandler.py
+        self._addedAttributeNames = set()
+
+    def __setattr__(self, attrName, value):
+        if hasattr(self, "_addedAttributeNames"):
+            self._addedAttributeNames.add(attrName)
+        super().__setattr__(attrName, value)
+
 
 def makeSchema(*classes, schema=None):
     if schema is None:

--- a/src/fontra/core/classes.py
+++ b/src/fontra/core/classes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from functools import partial
 from typing import Optional, get_args, get_type_hints
 import sys

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -161,7 +161,6 @@ class FontHandler:
             self.localData[("glyphs", glyphName)] = glyph
         return glyph
 
-    # @functools.lru_cache(250)  # see also reloadGlyphs
     def _getGlyph(self, glyphName):
         return asyncio.create_task(self._getGlyphFromBackend(glyphName))
 

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -41,6 +41,7 @@ backendAttrMapping = [
 
 backendGetterNames = {attr: "get" + baseName for attr, baseName in backendAttrMapping}
 backendSetterNames = {attr: "set" + baseName for attr, baseName in backendAttrMapping}
+backendDeleterNames = {attr: "delete" + baseName for attr, baseName in backendAttrMapping}
 
 
 @dataclass

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -163,7 +163,8 @@ class FontHandler:
 
     async def _getGlyphFromBackend(self, glyphName):
         glyph = await self.backend.getGlyph(glyphName)
-        self.updateGlyphDependencies(glyphName, glyph)
+        if glyph is not None:
+            self.updateGlyphDependencies(glyphName, glyph)
         return glyph
 
     async def getData(self, key):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -11,10 +11,10 @@ from .changes import (
     applyChange,
     collectChangePaths,
     patternDifference,
+    patternFromPath,
     patternIntersect,
     patternUnion,
     matchChangePattern,
-    pathToPattern,
 )
 from .classes import Font
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
@@ -408,7 +408,7 @@ def taskDoneHelper(task):
 def _writeKeyToPattern(writeKey):
     if not isinstance(writeKey, tuple):
         writeKey = (writeKey,)
-    return pathToPattern(writeKey)
+    return patternFromPath(writeKey)
 
 
 class DictSetDelTracker(UserDict):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -282,6 +282,8 @@ class FontHandler:
         for rootKey in sorted(rootObject.keys()):
             if rootKey == "glyphs":
                 for glyphName in sorted(glyphSet.keys()):
+                    if glyphName in glyphSet.addedKeys:
+                        self.localData["glyphs"][glyphName] = glyphSet[glyphName]
                     writeFunc = functools.partial(
                         self.backend.putGlyph, glyphName, deepcopy(glyphSet[glyphName])
                     )

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -33,14 +33,14 @@ def remoteMethod(method):
 
 
 backendAttrMapping = [
-    ("axes", "getGlobalAxes", "setGlobalAxes"),
-    ("glyphMap", "getGlyphMap", "setGlyphMap"),
-    ("lib", "getFontLib", "setFontLib"),
-    ("unitsPerEm", "getUnitsPerEm", "setUnitsPerEm"),
+    ("axes", "GlobalAxes"),
+    ("glyphMap", "GlyphMap"),
+    ("lib", "FontLib"),
+    ("unitsPerEm", "UnitsPerEm"),
 ]
 
-backendGetterNames = {attr: getter for attr, getter, setter in backendAttrMapping}
-backendSetterNames = {attr: setter for attr, getter, setter in backendAttrMapping}
+backendGetterNames = {attr: "get" + baseName for attr, baseName in backendAttrMapping}
+backendSetterNames = {attr: "set" + baseName for attr, baseName in backendAttrMapping}
 
 
 @dataclass

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -226,7 +226,7 @@ class FontHandler:
     ):
         # TODO: use finalChange, rollbackChange, editLabel for history recording
         # TODO: locking/checking
-        await self.updateServerGlyphs(finalChange, connection)
+        await self.updateLocalData(finalChange, connection)
         # return {"error": "computer says no"}
         if broadcast:
             await self.broadcastChange(finalChange, connection, False)
@@ -251,7 +251,7 @@ class FontHandler:
             *[connection.proxy.externalChange(change) for connection in connections]
         )
 
-    async def updateServerGlyphs(self, change, connection):
+    async def updateLocalData(self, change, connection):
         change = filterChangePattern(change, {"glyphs": None})
         glyphNames = [glyphName for _, glyphName in collectChangePaths(change, 2)]
         glyphs = {

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -282,8 +282,14 @@ class FontHandler:
                     writeKey = ("glyphs", glyphName)
                     await self.scheduleDataWrite(writeKey, writeFunc, connection)
             else:
-                # TODO
-                raise NotImplementedError()
+                method = getattr(self.backend, backendSetterNames[rootKey], None)
+                if method is None:
+                    logger.info(f"No backend write method found for {rootKey}")
+                    continue
+                functools.partial(
+                    method, deepcopy(rootObject[rootKey])
+                )
+                await self.scheduleDataWrite(rootKey, writeFunc, connection)
 
     async def scheduleDataWrite(self, writeKey, writeFunc, connection):
         if self._dataScheduledForWriting is None:

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -148,13 +148,7 @@ class FontHandler:
             self.connections.remove(connection)
 
     @remoteMethod
-    async def getGlyph(self, glyphName, *, connection):
-        glyph = self.localData.get(("glyphs", glyphName))
-        if glyph is None:
-            glyph = await self._getGlyph(glyphName)
-        return glyph
-
-    async def getLocalGlyph(self, glyphName):
+    async def getGlyph(self, glyphName, *, connection=None):
         glyph = self.localData.get(("glyphs", glyphName))
         if glyph is None:
             glyph = await self._getGlyph(glyphName)
@@ -267,7 +261,7 @@ class FontHandler:
                     if key == "glyphs"
                 ]
                 data = glyphSet = {
-                    glyphName: await self.getLocalGlyph(glyphName)
+                    glyphName: await self.getGlyph(glyphName)
                     for glyphName in glyphNames
                 }
             else:

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -163,7 +163,7 @@ class FontHandler:
         self.updateGlyphDependencies(glyphName, glyph)
         return glyph
 
-    async def getLocalData(self, key):
+    async def getData(self, key):
         data = self.localData.get(key)
         if data is None:
             data = await self._getData(key)
@@ -265,7 +265,7 @@ class FontHandler:
                     for glyphName in glyphNames
                 }
             else:
-                data = await self.getLocalData(rootKey)
+                data = await self.getData(rootKey)
             rootObject[rootKey] = data
 
         applyChange(rootObject, change)

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -203,14 +203,22 @@ class FontHandler:
 
     @remoteMethod
     async def subscribeChanges(self, pathOrPattern, wantLiveChanges, *, connection):
-        self._adjustMatchPattern(
-            patternUnion, pathOrPattern, wantLiveChanges, connection
+        pattern = (
+            patternFromPath(pathOrPattern)
+            if isinstance(pathOrPattern, list)
+            else pathOrPattern
         )
+        self._adjustMatchPattern(patternUnion, pattern, wantLiveChanges, connection)
 
     @remoteMethod
     async def unsubscribeChanges(self, pathOrPattern, wantLiveChanges, *, connection):
+        pattern = (
+            patternFromPath(pathOrPattern)
+            if isinstance(pathOrPattern, list)
+            else pathOrPattern
+        )
         self._adjustMatchPattern(
-            patternDifference, pathOrPattern, wantLiveChanges, connection
+            patternDifference, pattern, wantLiveChanges, connection
         )
 
     def _adjustMatchPattern(self, func, pathOrPattern, wantLiveChanges, connection):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -286,9 +286,7 @@ class FontHandler:
                 if method is None:
                     logger.info(f"No backend write method found for {rootKey}")
                     continue
-                functools.partial(
-                    method, deepcopy(rootObject[rootKey])
-                )
+                functools.partial(method, deepcopy(rootObject[rootKey]))
                 await self.scheduleDataWrite(rootKey, writeFunc, connection)
 
     async def scheduleDataWrite(self, writeKey, writeFunc, connection):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -292,10 +292,10 @@ class FontHandler:
                 # TODO
                 raise NotImplementedError()
 
-    async def scheduleDataWrite(self, key, writeFunc, connection):
+    async def scheduleDataWrite(self, writeKey, writeFunc, connection):
         if self._dataScheduledForWrite is None:
             # The write-"thread" is no longer running
-            await self.reloadGlyphs([glyphName])
+            await self.reloadData(_writeKeyToPattern(writeKey))
             await connection.proxy.messageFromServer(
                 "The glyph could not be saved.",
                 "The edit has been reverted.\n\n"  # no trailing comma
@@ -303,7 +303,7 @@ class FontHandler:
             )
             return
         shouldSignal = not self._dataScheduledForWrite
-        self._dataScheduledForWrite[key] = (writeFunc, connection)
+        self._dataScheduledForWrite[writeKey] = (writeFunc, connection)
         if shouldSignal:
             self._processWritesEvent.set()  # write: go!
             self._writingInProgressEvent.clear()

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -170,7 +170,7 @@ class FontHandler:
         data = self.localData.get(key)
         if data is None:
             data = await self._getData(key)
-            self.localData[key] = glyph
+            self.localData[key] = data
         return data
 
     async def _getData(self, key):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -330,6 +330,8 @@ class FontHandler:
         if glyphNames:
             await self.reloadGlyphs(glyphNames)
         else:
+            # TODO: implement reloadGlyphs in terms of reloadData
+            # instead of the other way around
             raise NotImplementedError()
 
     async def reloadGlyphs(self, glyphNames):

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -296,7 +296,7 @@ class FontHandler:
             # The write-"thread" is no longer running
             await self.reloadData(_writeKeyToPattern(writeKey))
             await connection.proxy.messageFromServer(
-                "The glyph could not be saved.",
+                "The data could not be saved.",
                 "The edit has been reverted.\n\n"  # no trailing comma
                 "The Fontra server got itself into trouble, please contact an admin.",
             )

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -139,7 +139,7 @@ class FontHandler:
             glyph = await self._getGlyph(glyphName)
         return glyph
 
-    async def getChangedGlyph(self, glyphName):
+    async def getLocalGlyph(self, glyphName):
         glyph = self.localData.get(("glyphs", glyphName))
         if glyph is None:
             glyph = await self._getGlyph(glyphName)
@@ -233,7 +233,7 @@ class FontHandler:
         change = filterChangePattern(change, {"glyphs": None})
         glyphNames = [glyphName for _, glyphName in collectChangePaths(change, 2)]
         glyphs = {
-            glyphName: await self.getChangedGlyph(glyphName) for glyphName in glyphNames
+            glyphName: await self.getLocalGlyph(glyphName) for glyphName in glyphNames
         }
         applyChange(dict(glyphs=glyphs), change)
         if not self.readOnly:

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -11,7 +11,6 @@ from .changes import (
     addToPattern,
     applyChange,
     collectChangePaths,
-    filterChangePattern,
     matchChangePattern,
     pathToPattern,
     subtractFromPattern,

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 import asyncio
-from collections import defaultdict
+from collections import UserDict, defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 import functools
@@ -41,7 +41,9 @@ backendAttrMapping = [
 
 backendGetterNames = {attr: "get" + baseName for attr, baseName in backendAttrMapping}
 backendSetterNames = {attr: "set" + baseName for attr, baseName in backendAttrMapping}
-backendDeleterNames = {attr: "delete" + baseName for attr, baseName in backendAttrMapping}
+backendDeleterNames = {
+    attr: "delete" + baseName for attr, baseName in backendAttrMapping
+}
 
 
 @dataclass

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -273,14 +273,14 @@ class FontHandler:
             else:
                 setattr(rootObject, rootKey, await self.getData(rootKey))
 
-        rootObject._trackAddedAttributeNames()
+        rootObject._trackAssignedAttributeNames()
 
         applyChange(rootObject, change)
 
         if self.readOnly:
             return
 
-        for rootKey in rootKeys + sorted(rootObject._addedAttributeNames):
+        for rootKey in rootKeys + sorted(rootObject._assignedAttributeNames):
             if rootKey == "glyphs":
                 for glyphName in sorted(glyphSet.keys()):
                     writeKey = ("glyphs", glyphName)
@@ -296,7 +296,7 @@ class FontHandler:
                     _ = self.localData.pop(writeKey, None)
                     await self.scheduleDataWrite(writeKey, writeFunc, connection)
             else:
-                if rootKey in rootObject._addedAttributeNames:
+                if rootKey in rootObject._assignedAttributeNames:
                     self.localData[rootKey] = getattr(rootObject, rootKey)
                 method = getattr(self.backend, backendSetterNames[rootKey], None)
                 if method is None:

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -282,7 +282,7 @@ class FontHandler:
         for rootKey in sorted(rootObject.keys()):
             if rootKey == "glyphs":
                 for glyphName in sorted(glyphSet.keys()):
-                    if glyphName in glyphSet.addedKeys:
+                    if glyphName in glyphSet.newKeys:
                         self.localData["glyphs"][glyphName] = glyphSet[glyphName]
                     writeFunc = functools.partial(
                         self.backend.putGlyph, glyphName, deepcopy(glyphSet[glyphName])
@@ -294,7 +294,7 @@ class FontHandler:
                     writeKey = ("glyphs", glyphName)
                     await self.scheduleDataWrite(writeKey, writeFunc, connection)
             else:
-                if rootKey in rootObject.addedKeys:
+                if rootKey in rootObject.newKeys:
                     self.localData[rootKey] = rootObject[rootKey]
                 method = getattr(self.backend, backendSetterNames[rootKey], None)
                 if method is None:
@@ -419,17 +419,17 @@ class DictSetDelTracker(UserDict):
     def __init__(self, data):
         super().__init__()
         self.data = data  # no copy
-        self.addedKeys = set()
+        self.newKeys = set()
         self.deletedKeys = set()
 
     def __setitem__(self, key, value):
         isNewItem = key not in self
         super().__setitem__(key, value)
         if isNewItem:
-            self.addedKeys.add(key)
+            self.newKeys.add(key)
             self.deletedKeys.discard(key)
 
     def __delitem__(self, key):
         _ = self.pop(key, None)
         self.deletedKeys.add(key)
-        self.addedKeys.discard(key)
+        self.newKeys.discard(key)

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -16,7 +16,7 @@ from .changes import (
     pathToPattern,
     subtractFromPattern,
 )
-from .classes import Font, classCastFuncs, classSchema
+from .classes import Font
 from .glyphnames import getSuggestedGlyphName, getUnicodeFromGlyphName
 from .lrucache import LRUCache
 

--- a/src/fontra/views/editor/editor.js
+++ b/src/fontra/views/editor/editor.js
@@ -713,6 +713,20 @@ export class EditorController {
     this.canvasController.setNeedsUpdate();
   }
 
+  async reloadData(reloadPattern) {
+    for (const rootKey of Object.keys(reloadPattern)) {
+      if (rootKey == "glyphs") {
+        const glyphNames = Object.keys(reloadPattern["glyphs"] || {});
+        if (glyphNames.length) {
+          await this.reloadGlyphs(glyphNames);
+        }
+      } else {
+        // TODO
+        console.log("reloading of non-glyph data is not yet implemented");
+      }
+    }
+  }
+
   async reloadGlyphs(glyphNames) {
     if (glyphNames.includes(this.sceneController.getSelectedGlyphName())) {
       // If the glyph being edited is among the glyphs to be reloaded,

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -6,8 +6,8 @@ from fontra.core.changes import (
     applyChange,
     collectChangePaths,
     filterChangePattern,
-    pathToPattern,
     patternDifference,
+    patternFromPath,
     patternIntersect,
     patternUnion,
     matchChangePattern,
@@ -420,6 +420,6 @@ def test_collectChangePaths(change, depth, expectedPaths):
         (["a", "b", "c"], {"a": {"b": {"c": None}}}),
     ],
 )
-def test_pathToPattern(path, expectedPattern):
-    pattern = pathToPattern(path)
+def test_patternFromPath(path, expectedPattern):
+    pattern = patternFromPath(path)
     assert expectedPattern == pattern

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -3,14 +3,14 @@ import json
 import pathlib
 import pytest
 from fontra.core.changes import (
-    addToPattern,
     applyChange,
     collectChangePaths,
     filterChangePattern,
-    intersectPatterns,
-    matchChangePattern,
     pathToPattern,
-    subtractFromPattern,
+    patternDifference,
+    patternIntersect,
+    patternUnion,
+    matchChangePattern,
 )
 
 
@@ -69,7 +69,7 @@ def test_applyChange(testName, inputDataName, change, expectedData):
 )
 def test_addPathToPattern(pattern, path, expectedPattern):
     orgPattern = deepcopy(pattern)
-    newPattern = addToPattern(pattern, path)
+    newPattern = patternUnion(pattern, path)
     assert orgPattern == pattern
     assert expectedPattern == newPattern
 
@@ -86,7 +86,7 @@ def test_addPathToPattern(pattern, path, expectedPattern):
 )
 def test_subtractPathFromPattern(pattern, path, expectedPattern):
     orgPattern = deepcopy(pattern)
-    newPattern = subtractFromPattern(pattern, path)
+    newPattern = patternDifference(pattern, path)
     assert orgPattern == pattern
     assert expectedPattern == newPattern
 
@@ -107,7 +107,7 @@ def test_subtractPathFromPattern(pattern, path, expectedPattern):
 )
 def test_addPatternToPattern(pattern, patternToAdd, expectedPattern):
     orgPattern = deepcopy(pattern)
-    newPattern = addToPattern(pattern, patternToAdd)
+    newPattern = patternUnion(pattern, patternToAdd)
     assert orgPattern == pattern
     assert expectedPattern == newPattern
 
@@ -132,7 +132,7 @@ def test_addPatternToPattern(pattern, patternToAdd, expectedPattern):
 )
 def test_subtractPatternFromPattern(pattern, patternToRemove, expectedPattern):
     orgPattern = deepcopy(pattern)
-    newPattern = subtractFromPattern(pattern, patternToRemove)
+    newPattern = patternDifference(pattern, patternToRemove)
     assert orgPattern == pattern
     assert expectedPattern == newPattern
 
@@ -168,8 +168,8 @@ def test_subtractPatternFromPattern(pattern, patternToRemove, expectedPattern):
         ),
     ],
 )
-def test_intersectPatterns(patternA, patternB, expectedPattern):
-    pattern = intersectPatterns(patternA, patternB)
+def test_patternIntersect(patternA, patternB, expectedPattern):
+    pattern = patternIntersect(patternA, patternB)
     assert expectedPattern == pattern
 
 

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -7,6 +7,7 @@ from fontra.core.changes import (
     applyChange,
     collectChangePaths,
     filterChangePattern,
+    intersectPatterns,
     matchChangePattern,
     pathToPattern,
     subtractFromPattern,
@@ -134,6 +135,42 @@ def test_subtractPatternFromPattern(pattern, patternToRemove, expectedPattern):
     newPattern = subtractFromPattern(pattern, patternToRemove)
     assert orgPattern == pattern
     assert expectedPattern == newPattern
+
+
+@pytest.mark.parametrize(
+    "patternA, patternB, expectedPattern",
+    [
+        ({}, {}, {}),
+        ({"A": None}, {}, {}),
+        ({}, {"A": None}, {}),
+        ({"A": None}, {"B": None}, {}),
+        ({"A": None}, {"A": None}, {"A": None}),
+        ({"A": None, "B": None}, {"A": None}, {"A": None}),
+        ({"A": None}, {"A": None, "B": None}, {"A": None}),
+        ({"A": {"X": None}}, {"A": {"X": None}}, {"A": {"X": None}}),
+        ({"A": {"X": None}}, {"A": {"Y": None}}, {}),
+        ({"A": {"X": None}}, {"A": {"X": None, "Y": None}}, {"A": {"X": None}}),
+        (
+            {"A": {"B": {"X": None}}},
+            {"A": {"B": {"X": None}}},
+            {"A": {"B": {"X": None}}},
+        ),
+        ({"A": {"B": {"X": None}}}, {"A": {"B": {"Y": None}}}, {}),
+        (
+            {"A": {"B": {"X": None, "Y": None}}},
+            {"A": {"B": {"X": None}}},
+            {"A": {"B": {"X": None}}},
+        ),
+        (
+            {"A": {"B": {"X": None}}},
+            {"A": {"B": {"X": None, "Y": None}}},
+            {"A": {"B": {"X": None}}},
+        ),
+    ],
+)
+def test_intersectPatterns(patternA, patternB, expectedPattern):
+    pattern = intersectPatterns(patternA, patternB)
+    assert expectedPattern == pattern
 
 
 @pytest.mark.parametrize(

--- a/test-py/test_changes.py
+++ b/test-py/test_changes.py
@@ -55,7 +55,7 @@ def test_applyChange(testName, inputDataName, change, expectedData):
 
 
 @pytest.mark.parametrize(
-    "pattern, path, expectedPattern",
+    "patternA, path, expectedPattern",
     [
         ({}, [], {}),
         ({"A": None}, [], {"A": None}),
@@ -67,15 +67,16 @@ def test_applyChange(testName, inputDataName, change, expectedData):
         ({"A": {"B": None}}, ["A"], {"A": None}),
     ],
 )
-def test_addPathToPattern(pattern, path, expectedPattern):
-    orgPattern = deepcopy(pattern)
-    newPattern = patternUnion(pattern, path)
-    assert orgPattern == pattern
+def test_addPathToPattern(patternA, path, expectedPattern):
+    patternB = patternFromPath(path)
+    orgPattern = deepcopy(patternA)
+    newPattern = patternUnion(patternA, patternB)
+    assert orgPattern == patternA
     assert expectedPattern == newPattern
 
 
 @pytest.mark.parametrize(
-    "pattern, path, expectedPattern",
+    "patternA, path, expectedPattern",
     [
         ({"A": None}, ["A"], {}),
         ({"A": {"B": None}}, ["A", "B"], {}),
@@ -84,10 +85,11 @@ def test_addPathToPattern(pattern, path, expectedPattern):
         ({"A": {"B": None}}, ["A"], {}),
     ],
 )
-def test_subtractPathFromPattern(pattern, path, expectedPattern):
-    orgPattern = deepcopy(pattern)
-    newPattern = patternDifference(pattern, path)
-    assert orgPattern == pattern
+def test_subtractPathFromPattern(patternA, path, expectedPattern):
+    patternB = patternFromPath(path)
+    orgPattern = deepcopy(patternA)
+    newPattern = patternDifference(patternA, patternB)
+    assert orgPattern == patternA
     assert expectedPattern == newPattern
 
 

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -122,3 +122,10 @@ async def test_fontHandler_editGlyph(testFontHandler):
 
     # give the event loop a moment to clean up
     await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_fontHandler_getLocalData(testFontHandler):
+    async with asyncClosing(testFontHandler):
+        unitsPerEm = await testFontHandler.getLocalData("unitsPerEm")
+        assert 1000 == unitsPerEm

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -63,7 +63,7 @@ async def test_fontHandler_basic(testFontHandler):
 async def test_fontHandler_externalChange(testFontHandler):
     async with asyncClosing(testFontHandler):
         await testFontHandler.startTasks()
-        glyph = await testFontHandler.getChangedGlyph("A")
+        glyph = await testFontHandler.getLocalGlyph("A")
         assert 20 == glyph.layers[0].glyph.path.coordinates[0]
 
         dsDoc = testFontHandler.backend.dsDoc
@@ -74,14 +74,14 @@ async def test_fontHandler_externalChange(testFontHandler):
         glifPath.write_text(glifData)
 
         # We should see the "before", as it's cached
-        glyph = await testFontHandler.getChangedGlyph("A")
+        glyph = await testFontHandler.getLocalGlyph("A")
         assert 20 == glyph.layers[0].glyph.path.coordinates[0]
 
         await asyncio.sleep(0.3)
 
         # We should see the "after", because the external change
         # watcher cleared the cache
-        glyph = await testFontHandler.getChangedGlyph("A")
+        glyph = await testFontHandler.getLocalGlyph("A")
         assert -100 == glyph.layers[0].glyph.path.coordinates[0]
 
 

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -125,7 +125,7 @@ async def test_fontHandler_editGlyph(testFontHandler):
 
 
 @pytest.mark.asyncio
-async def test_fontHandler_getLocalData(testFontHandler):
+async def test_fontHandler_getData(testFontHandler):
     async with asyncClosing(testFontHandler):
-        unitsPerEm = await testFontHandler.getLocalData("unitsPerEm")
+        unitsPerEm = await testFontHandler.getData("unitsPerEm")
         assert 1000 == unitsPerEm

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -129,3 +129,26 @@ async def test_fontHandler_getData(testFontHandler):
     async with asyncClosing(testFontHandler):
         unitsPerEm = await testFontHandler.getData("unitsPerEm")
         assert 1000 == unitsPerEm
+
+
+@pytest.mark.asyncio
+async def test_fontHandler_setData(testFontHandler):
+    async with asyncClosing(testFontHandler):
+        glyphMap = await testFontHandler.getData("glyphMap")
+        assert [65, 97] == glyphMap["A"]
+        change = {
+            "p": ["glyphMap"],
+            "f": "=",
+            "a": ["A", [97]],
+        }
+        rollbackChange = {
+            "p": ["glyphMap"],
+            "f": "=",
+            "a": ["A", [65, 97]],
+        }
+        await testFontHandler.editFinal(
+            change, rollbackChange, "Test edit", False, connection=None
+        )
+
+        glyphMap = await testFontHandler.getData("glyphMap")
+        assert [97] == glyphMap["A"]

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
+import logging
 import pathlib
 import shutil
 import pytest
@@ -132,7 +133,8 @@ async def test_fontHandler_getData(testFontHandler):
 
 
 @pytest.mark.asyncio
-async def test_fontHandler_setData(testFontHandler):
+async def test_fontHandler_setData(testFontHandler, caplog):
+    caplog.set_level(logging.INFO)
     async with asyncClosing(testFontHandler):
         glyphMap = await testFontHandler.getData("glyphMap")
         assert [65, 97] == glyphMap["A"]
@@ -152,3 +154,4 @@ async def test_fontHandler_setData(testFontHandler):
 
         glyphMap = await testFontHandler.getData("glyphMap")
         assert [97] == glyphMap["A"]
+    assert "No backend write method found for glyphMap" == caplog.records[0].message

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -63,7 +63,7 @@ async def test_fontHandler_basic(testFontHandler):
 async def test_fontHandler_externalChange(testFontHandler):
     async with asyncClosing(testFontHandler):
         await testFontHandler.startTasks()
-        glyph = await testFontHandler.getLocalGlyph("A")
+        glyph = await testFontHandler.getGlyph("A")
         assert 20 == glyph.layers[0].glyph.path.coordinates[0]
 
         dsDoc = testFontHandler.backend.dsDoc
@@ -74,14 +74,14 @@ async def test_fontHandler_externalChange(testFontHandler):
         glifPath.write_text(glifData)
 
         # We should see the "before", as it's cached
-        glyph = await testFontHandler.getLocalGlyph("A")
+        glyph = await testFontHandler.getGlyph("A")
         assert 20 == glyph.layers[0].glyph.path.coordinates[0]
 
         await asyncio.sleep(0.3)
 
         # We should see the "after", because the external change
         # watcher cleared the cache
-        glyph = await testFontHandler.getLocalGlyph("A")
+        glyph = await testFontHandler.getGlyph("A")
         assert -100 == glyph.layers[0].glyph.path.coordinates[0]
 
 

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -174,7 +174,6 @@ async def test_fontHandler_setData_unitsPerEm(testFontHandler, caplog):
         await testFontHandler.editFinal(
             change, rollbackChange, "Test edit", False, connection=None
         )
-        await asyncio.sleep(0.1)
 
         unitsPerEm = await testFontHandler.getData("unitsPerEm")
         assert 2000 == unitsPerEm

--- a/test-py/test_fonthandler.py
+++ b/test-py/test_fonthandler.py
@@ -155,3 +155,28 @@ async def test_fontHandler_setData(testFontHandler, caplog):
         glyphMap = await testFontHandler.getData("glyphMap")
         assert [97] == glyphMap["A"]
     assert "No backend write method found for glyphMap" == caplog.records[0].message
+
+
+@pytest.mark.asyncio
+async def test_fontHandler_setData_unitsPerEm(testFontHandler, caplog):
+    caplog.set_level(logging.INFO)
+    async with asyncClosing(testFontHandler):
+        unitsPerEm = await testFontHandler.getData("unitsPerEm")
+        assert 1000 == unitsPerEm
+        change = {
+            "f": "=",
+            "a": ["unitsPerEm", 2000],
+        }
+        rollbackChange = {
+            "f": "=",
+            "a": ["unitsPerEm", 1000],
+        }
+        await testFontHandler.editFinal(
+            change, rollbackChange, "Test edit", False, connection=None
+        )
+        await asyncio.sleep(0.1)
+
+        unitsPerEm = await testFontHandler.getData("unitsPerEm")
+        assert 2000 == unitsPerEm
+
+    assert "No backend write method found for unitsPerEm" == caplog.records[0].message


### PR DESCRIPTION
- Use LRU cache for local data
- Generalize writing to the backend

TODO:
- [x] Implement `reloadData` on the client side
- [x] Figure out a fundamental problem with `font.unitsPerEm`: it's the only top-level value which is a scalar, which doesn't play nice with `collectChangePaths()`, since it returns an empty path
- [x] Record setitem and delitem for `font.glyphs` so we can track new and deleted glyphs (doing the same at the `font` level may help to solve the `unitsPerEm` issue