### PR TITLE
Rethink changes on uncached data

### DIFF
--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -14,6 +14,7 @@ from fontTools.ufoLib import UFOReader
 from fontTools.ufoLib.glifLib import GlyphSet
 from .ufo_utils import extractGlyphNameAndUnicodes
 import watchfiles
+from ..core.changes import applyChange
 from ..core.classes import (
     Component,
     Layer,
@@ -121,7 +122,7 @@ class DesignspaceBackend:
             glifFileNames[fileName] = glyphName
 
     async def getGlyphMap(self):
-        return self.glyphMap
+        return dict(self.glyphMap)
 
     async def getGlyph(self, glyphName):
         if glyphName not in self.glyphMap:
@@ -249,15 +250,17 @@ class DesignspaceBackend:
         async for changes in watchfiles.awatch(*ufoPaths):
             changedItems = self._analyzeExternalChanges(changes)
 
-            glyphMapUpdates = []
+            glyphMapUpdates = {}
+
+            # TODO: update glyphMap for changed non-new glyphs
 
             for glyphName in changedItems.newGlyphs:
                 glifData = self.defaultSourceGlyphSet.getGLIF(glyphName)
                 gn, unicodes = extractGlyphNameAndUnicodes(glifData)
-                glyphMapUpdates.append((glyphName, unicodes))
+                glyphMapUpdates[glyphName] = unicodes
 
             for glyphName in changedItems.deletedGlyphs:
-                glyphMapUpdates.append((glyphName, None))
+                glyphMapUpdates[glyphName] = None
 
             externalChange = (
                 _makeGlyphMapChange(glyphMapUpdates) if glyphMapUpdates else None
@@ -268,6 +271,10 @@ class DesignspaceBackend:
                 if changedItems.changedGlyphs
                 else None
             )
+
+            # if externalChange:
+            #     rootObject = {"glyphMap": self.glyphMap}
+            #     applyChange(rootObject, externalChange)
 
             if externalChange or reloadPattern:
                 yield externalChange, reloadPattern
@@ -343,11 +350,11 @@ class DesignspaceBackend:
 def _makeGlyphMapChange(glyphMapUpdates):
     changes = [
         {"f": "=", "a": [glyphName, unicodes]}
-        for glyphName, unicodes in glyphMapUpdates
+        for glyphName, unicodes in glyphMapUpdates.items()
         if unicodes is not None
     ] + [
         {"f": "d", "a": [glyphName]}
-        for glyphName, unicodes in glyphMapUpdates
+        for glyphName, unicodes in glyphMapUpdates.items()
         if unicodes is None
     ]
     glyphMapChange = {"p": ["glyphMap"]}

--- a/src/fontra/backends/designspace.py
+++ b/src/fontra/backends/designspace.py
@@ -272,9 +272,9 @@ class DesignspaceBackend:
                 else None
             )
 
-            # if externalChange:
-            #     rootObject = {"glyphMap": self.glyphMap}
-            #     applyChange(rootObject, externalChange)
+            if externalChange:
+                rootObject = {"glyphMap": self.glyphMap}
+                applyChange(rootObject, externalChange)
 
             if externalChange or reloadPattern:
                 yield externalChange, reloadPattern

--- a/src/fontra/client/core/font-controller.js
+++ b/src/fontra/client/core/font-controller.js
@@ -2,6 +2,7 @@ import {
   applyChange,
   collectChangePaths,
   consolidateChanges,
+  filterChangePattern,
   matchChangePath,
 } from "./changes.js";
 import { getGlyphMapProxy, makeCharacterMapFromGlyphMap } from "./cmap.js";
@@ -219,6 +220,9 @@ export class FontController {
   }
 
   async applyChange(change, isExternalChange) {
+    const cachedPattern = this.getCachedDataPattern();
+    change = filterChangePattern(change, cachedPattern);
+
     const glyphNames = collectGlyphNames(change);
     const glyphSet = {};
     for (const glyphName of glyphNames) {
@@ -234,6 +238,19 @@ export class FontController {
         delete this.undoStacks[glyphName];
       }
     }
+  }
+
+  getCachedDataPattern() {
+    const cachedPattern = {};
+    for (const rootKey of Object.keys(this._rootObject)) {
+      cachedPattern[rootKey] = null;
+    }
+    const glyphsPattern = {};
+    for (const glyphName of this.getCachedGlyphNames()) {
+      glyphsPattern[glyphName] = null;
+    }
+    cachedPattern["glyphs"] = glyphsPattern;
+    return cachedPattern;
   }
 
   *iterGlyphMadeOf(glyphName) {

--- a/src/fontra/core/fonthandler.py
+++ b/src/fontra/core/fonthandler.py
@@ -200,7 +200,7 @@ class FontHandler:
 
     @remoteMethod
     async def getFontLib(self, *, connection):
-        return await self.backend.getFontLib()
+        return await self.getData("lib")
 
     def _getClientData(self, connection, key, default=None):
         return self.clientData[connection.clientUUID].get(key, default)


### PR DESCRIPTION
Don't retrieve data just because it is referenced in a change: filter the change so it will only reference data we already have. Doing otherwise makes things much harder, especially when responding to external changes.